### PR TITLE
Add usage of npm instead of yarn as an option to the bundle-ios command

### DIFF
--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require('./build');

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "private": true,
   "bin": {
-    "react-native-brownfield": "build/index.js"
+    "react-native-brownfield": "index.js"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@types/node": "^13.1.7",
-    "commander": "^4.0.1"
+    "commander": "^4.0.1",
+    "find-up": "^4.1.0"
   }
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -14,6 +14,7 @@ program
   .command('build-ios')
   .description('build native artifact')
   .option('-e, --entryFile <entryFile>', 'Remove recursively')
+  .option('--useNpm', 'use npm instead of yarn')
   .action(buildIOSArtifact);
 
 program.parse(process.argv);

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -1,3 +1,4 @@
 export type BuildArtifact = {
   entryFile: string;
+  useNpm?: boolean;
 };


### PR DESCRIPTION
The index.js file containing `require('./build')` is needed here in order for yarn not to fail on first installation, when the build folder doesn't yet exist.