### PR TITLE
Improve cli

### DIFF
--- a/packages/cli/src/commands/build-ios.ts
+++ b/packages/cli/src/commands/build-ios.ts
@@ -46,13 +46,13 @@ export default async function buildArtifact(args: BuildPlatform) {
     return;
   }
 
-  if (args.outputDir) {
-    try {
-      execSync(
-        `cp -r ${buildDir}/ios/build/Build/Products/Release-iphoneos/ReactNativeBrownfield.framework ${rootDir}/${args.outputDir}`,
-      );
-    } catch (e) {
-      console.log(e);
-    }
+  const copyDir = args.outputDir ? `${rootDir}/${args.outputDir}` : rootDir;
+
+  try {
+    execSync(
+      `cp -r ${buildDir}/ios/build/Build/Products/Release-iphoneos/ReactNativeBrownfield.framework ${copyDir}`,
+    );
+  } catch (e) {
+    console.log(e);
   }
 }

--- a/packages/cli/src/commands/build-ios.ts
+++ b/packages/cli/src/commands/build-ios.ts
@@ -46,4 +46,14 @@ export default async function buildArtifact(args: BuildPlatform) {
     console.error(e);
     return;
   }
+
+  if (args.outputDir) {
+    try {
+      execSync(
+        `cp ${buildDir}/ios/build/Build/Products/Release-iphoneos/ReactNativeBrownfield.framework ${rootDir}/${args.outputDir}`,
+      );
+    } catch (e) {
+      console.log(e);
+    }
+  }
 }

--- a/packages/cli/src/commands/build-ios.ts
+++ b/packages/cli/src/commands/build-ios.ts
@@ -50,7 +50,7 @@ export default async function buildArtifact(args: BuildPlatform) {
 
   try {
     execSync(
-      `cp -r ${buildDir}/ios/build/Build/Products/Release-iphoneos/ReactNativeBrownfield.framework ${copyDir}`,
+      `cp -r ${buildDir}/ios/build/Build/Products/Release-iphoneos/ReactNativeBrownfield.framework ${copyDir}/ReactNativeBrownfield.framework`,
     );
   } catch (e) {
     console.log(e);

--- a/packages/cli/src/commands/build-ios.ts
+++ b/packages/cli/src/commands/build-ios.ts
@@ -41,7 +41,6 @@ export default async function buildArtifact(args: BuildPlatform) {
       `cd ${buildDir}/ios && xcodebuild -workspace ReactNativeBrownfield.xcworkspace -scheme ReactNativeBrownfield -sdk iphoneos -derivedDataPath build`,
     );
     console.log(result.toString());
-    execSync('popd');
   } catch (e) {
     console.error(e);
     return;
@@ -50,7 +49,7 @@ export default async function buildArtifact(args: BuildPlatform) {
   if (args.outputDir) {
     try {
       execSync(
-        `cp ${buildDir}/ios/build/Build/Products/Release-iphoneos/ReactNativeBrownfield.framework ${rootDir}/${args.outputDir}`,
+        `cp -r ${buildDir}/ios/build/Build/Products/Release-iphoneos/ReactNativeBrownfield.framework ${rootDir}/${args.outputDir}`,
       );
     } catch (e) {
       console.log(e);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -15,14 +15,15 @@ program
   .command('build-ios')
   .description('build native artifact')
   .option('-e, --entryFile <entryFile>', 'Remove recursively')
-  .option('--useNpm', 'use npm instead of yarn')
+  .option('--useNpm', 'Use npm instead of yarn')
+  .option('-o, --outputDir <outputDir>', 'Relative output directory')
   .action(buildIOSArtifact);
 
 program
   .command('build-android')
   .description('build android')
   .option('-e, --entryFile <entryFile>', 'Remove recursively')
-  .option('--useNpm', 'use npm instead of yarn')
+  .option('--useNpm', 'Use npm instead of yarn')
   .action(buildAndroid);
 
 program.parse(process.argv);

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -1,6 +1,7 @@
 export type BuildPlatform = {
   entryFile: string;
   useNpm?: boolean;
+  outputDir?: string;
 };
 
 export type Platform = 'ios' | 'android';


### PR DESCRIPTION
- Add `output dir` options to ios build command + copying `ReactNativeBrownfield.framework` to chosen directory
- Remove unnecessary `popd` command
- Rename options descriptions to all start with capital letter

