### PR TITLE
Added the ability to initialize module with your own bridge

### DIFF
--- a/ios/ReactNativeBrownfield.m
+++ b/ios/ReactNativeBrownfield.m
@@ -62,7 +62,7 @@
 
 - (NSURL *)sourceURLForBridge:(RCTBridge *)bridge {
     #if DEBUG
-        return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:_entryFile fallbackResource:_fallbackResource];
+        return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index"];
     #else
         NSArray<NSString *> *resourceURLComponents = [_bundlePath componentsSeparatedByString:@"."];
         NSRange withoutLast;

--- a/ios/ReactNativeViewController.h
+++ b/ios/ReactNativeViewController.h
@@ -1,4 +1,5 @@
 #import <UIKit/UIKit.h>
+#import <React/RCTBridge.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -6,9 +7,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, copy) NSString *moduleName;
 @property (nonatomic, copy, nullable) NSDictionary *initialProperties;
+@property (nonatomic, copy, nullable) RCTBridge *currentBridge;
 
--(instancetype)initWithModuleName:(NSString *)moduleName;
--(instancetype)initWithModuleName:(NSString *)moduleName andInitialProperties:(NSDictionary*)initialProperties;
+-(instancetype)initWithModuleName:(NSString *)moduleName withBridge:(RCTBridge * _Nullable)bridge;
+-(instancetype)initWithModuleName:(NSString *)moduleName withBridge:(RCTBridge * _Nullable)bridge andInitialProperties:(NSDictionary* _Nullable)initialProperties;
 
 @end
 

--- a/ios/ReactNativeViewController.m
+++ b/ios/ReactNativeViewController.m
@@ -8,29 +8,33 @@
 
 @synthesize moduleName = _moduleName;
 @synthesize initialProperties = _initialProperties;
+@synthesize currentBridge = _currentBridge;
 
--(instancetype)initWithModuleName:(NSString *)moduleName {
-    return [self initWithModuleName:moduleName andInitialProperties:nil];
+-(instancetype)initWithModuleName:(NSString *)moduleName withBridge:(RCTBridge *)bridge {
+    return [self initWithModuleName:moduleName withBridge:bridge andInitialProperties:nil];
 }
 
--(instancetype)initWithModuleName:(NSString *)moduleName
-             andInitialProperties:(NSDictionary*)initialProperties {
+-(instancetype)initWithModuleName:(NSString *)moduleName withBridge:(RCTBridge *)bridge andInitialProperties:(NSDictionary*)initialProperties {
     self = [super init];
     _moduleName = moduleName;
     _initialProperties = initialProperties;
+    _currentBridge = bridge;
     
     return self;
 }
 
 -(void)viewDidLoad {
-    RCTBridge *bridge = [[ReactNativeBrownfield shared] bridge];
-    if (bridge == nil) {
+    if(_currentBridge == nil) {
+        _currentBridge = [[ReactNativeBrownfield shared] bridge];
+    }
+
+    if (_currentBridge == nil) {
         NSLog(@"Error: You need to start React Native in order to use ReactNativeViewController, make sure to run [[BridgeManager shared] startReactNative] before instantiating it.");
         return;
     }
 
     if (_moduleName) {
-        RCTRootView *reactView = [[RCTRootView alloc] initWithBridge:bridge moduleName:_moduleName initialProperties:_initialProperties];
+        RCTRootView *reactView = [[RCTRootView alloc] initWithBridge:_currentBridge moduleName:_moduleName initialProperties:_initialProperties];
         self.view = reactView;
         
         [[NSNotificationCenter defaultCenter]

--- a/ios/ReactNativeViewController.m
+++ b/ios/ReactNativeViewController.m
@@ -61,7 +61,7 @@
     BOOL animated = [[userInfo objectForKey:@"animated"] boolValue];
     
     dispatch_async(dispatch_get_main_queue(), ^{
-        [self.navigationController popViewControllerAnimated:animated];
+        [self dismissViewControllerAnimated:YES completion:nil];
     });
 }
 


### PR DESCRIPTION
### Summary

In our use-case we already had a React Native bridge initialised. Our app is built with React Native but integrated a native only library, one of the actions from this library was intended to open one of our existing pages in React Native, hence this implementation. This use-case seems as if it would be useful for others, it does not change existing behaviour.

This solves the problem of not being able to init a module using your own `bridge` instance.

### Todo

- [x] Objective-C Implementation

```objective-c
[[ReactNativeViewController alloc] initWithModuleName:@"BillingPlansScreen" withBridge:bridge];
```
- [ ] Swift Implementation
- [ ] Java Implementation
- [ ] Kotlin Implementation

I'll work on the remaining implementations over next week or two, just wanted to get a sense of what others think about this feature.
