### PR TITLE
docs: correct ios manual link path

### DIFF
--- a/docs/OBJECTIVE_C.md
+++ b/docs/OBJECTIVE_C.md
@@ -20,7 +20,7 @@ Run the following command in your terminal:
 Add the following line to your `Podfile`:
 
 ```ruby
-  pod 'ReactNativeBrownfield', :path => '../node_modules/@callstack/react-native-brownfield/ios'
+  pod 'ReactNativeBrownfield', :path => '../node_modules/@callstack/react-native-brownfield'
 ```
 </details>
 

--- a/docs/SWIFT.md
+++ b/docs/SWIFT.md
@@ -34,7 +34,7 @@ Run the following command in your terminal:
 Add the following line to your `Podfile`:
 
 ```ruby
-  pod 'ReactNativeBrownfield', :path => '../node_modules/@callstack/react-native-brownfield/ios'
+  pod 'ReactNativeBrownfield', :path => '../node_modules/@callstack/react-native-brownfield'
 ```
 </details>
 


### PR DESCRIPTION
### Summary

Podspec file is in the package root not the ios folder

Update the manual linking instructions in the docs to have this correct path

### Test plan

N/A
