### PR TITLE
feat: resolve bundle task for local projects

### DIFF
--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/artifacts/FlavorArtifact.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/artifacts/FlavorArtifact.kt
@@ -12,6 +12,7 @@ package com.callstack.react.brownfield.artifacts
 
 import com.android.build.gradle.LibraryExtension
 import com.android.build.gradle.api.LibraryVariant
+import com.android.build.gradle.internal.tasks.factory.dependsOn
 import com.callstack.react.brownfield.processors.VariantTaskProvider
 import com.callstack.react.brownfield.shared.BaseProject
 import org.gradle.api.Project
@@ -41,6 +42,8 @@ class FlavorArtifact(private val variant: LibraryVariant, private val variantTas
         val artifactProject = getArtifactProject(unResolvedArtifact)
         val bundleProvider: TaskProvider<Task>? =
             artifactProject?.let { getBundleTaskProvider(it, variant) }
+
+        project.tasks.named("preBuild").dependsOn("${artifactProject?.path}:${bundleProvider?.name}")
 
         val identifier =
             DefaultModuleVersionIdentifier.newId(

--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/processors/JNILibsProcessor.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/processors/JNILibsProcessor.kt
@@ -57,16 +57,22 @@ class JNILibsProcessor : BaseProject() {
                 .toMutableMap()
 
         files?.forEach { folder ->
-            folder.listFiles()?.forEach { file ->
-                if (existingJNILibs[folder.name]?.contains(file.name) == true) {
-                    val deleted = file.delete()
-                    if (!deleted) {
-                        Logging.log("Failed to delete: ${file.name}")
-                    }
+            val libFiles = folder.listFiles() ?: return@forEach
+            val libList = existingJNILibs[folder.name] ?: return@forEach
+
+            libFiles.forEach { file ->
+                if (file.name in libList) {
+                    deleteFile(file)
                 } else {
-                    existingJNILibs[folder.name]?.add(file.name)
+                    libList.add(file.name)
                 }
             }
+        }
+    }
+
+    private fun deleteFile(file: File) {
+        if (!file.delete()) {
+            Logging.log("Failed to delete: ${file.name}")
         }
     }
 }

--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/processors/ProguardProcessor.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/processors/ProguardProcessor.kt
@@ -76,7 +76,7 @@ class ProguardProcessor(variant: LibraryVariant) : BaseProject() {
                 }
             Utils.mergeFiles(files, outputFileToMerge)
         } catch (e: NoSuchFileException) {
-            Logging.log(e.printStackTrace())
+            Logging.log(e)
         }
     }
 }

--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/processors/VariantProcessor.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/processors/VariantProcessor.kt
@@ -119,11 +119,12 @@ class VariantProcessor(private val variant: LibraryVariant) : BaseProject() {
         prepareTask: TaskProvider<Task>,
         bundleTask: TaskProvider<Task>,
     ) {
-        val archiveLibrary = AndroidArchiveLibrary(
-            project,
-            artifact,
-            variant.name
-        )
+        val archiveLibrary =
+            AndroidArchiveLibrary(
+                project,
+                artifact,
+                variant.name,
+            )
         aarLibraries.add(archiveLibrary)
         aarLibrariesProperty.add(archiveLibrary)
 

--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/shared/BaseProject.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/shared/BaseProject.kt
@@ -7,7 +7,7 @@ open class BaseProject {
     private var _project: Project? = null
 
     var project: Project
-        get() = _project ?: throw IllegalStateException("Project has not been initialized")
+        get() = checkNotNull(_project) { "Project has not been initialized" }
         set(value) {
             _project = value
         }


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

This PR adds the support to auto resolving the bundle task for local projects. Previously, we had to manually add the bundle task for the used third-party RN libraries:

```gradle
    dependsOn(":react-native-safe-area-context:bundle${buildType}Aar")
    dependsOn(":react-native-screens:bundle${buildType}Aar")
    dependsOn(":react-native-reanimated:bundle${buildType}Aar")
```

With this PR, we don't need to do it anymore. 🚀 


### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

- checkout to this PR/branch
- After `yarn install`, run from the root `yarn brownfield:plugin:publish:local`
- If you have a separate module for handling brownfield implementations in your RN App, add the following patch. If you have everything inside `app` module, you can still add the below patch:

```diff
diff --git a/android/build.gradle b/android/build.gradle
index 3dd1ac9..0db4ded 100644
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,6 +16,7 @@ buildscript {
         }
+        mavenLocal()
         google()
         mavenCentral()
     }
@@ -23,7 +24,7 @@ buildscript {
         classpath("com.android.tools.build:gradle")
         classpath("com.facebook.react:react-native-gradle-plugin")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin")
+       classpath("com.callstack.react:brownfield-gradle-plugin:0.1.0")
     }
 }
 
diff --git a/android/rnbrownfield/build.gradle.kts b/android/rnbrownfield/build.gradle.kts
index b915003..e387075 100644
--- a/android/rnbrownfield/build.gradle.kts
+++ b/android/rnbrownfield/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")
+    id("com.callstack.react.brownfield")
     `maven-publish`
     id("com.facebook.react")
 }
@@ -10,8 +10,8 @@ react {
     autolinkLibrariesWithApp()
 }
 
 val appProject = project(":app")
```
- generate Aar from your RN App and test it in the native App.
