### PR TITLE
feat: update new apis, reword docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,12 @@
 - **Easily integrate** React Native with existing native app
 - Start React Native with **one method** and invoke code as soon as it's loaded
 - Compatible with **both old and new React Native architecture**! 
-- Reuse the same instance of React Native **instance** between different components
+- Reuse the same instance of React Native between different components
 - Use predefined **native building blocks** - crafted for React Native
 - Disable and enable **native gestures and hardware buttons** from JavaScript
 - Works well with **any native navigation** pattern, as well as every React Native JavaScript based navigation
 - Compatible with all native languages **Objective-C**, **Swift**, **Java** and **Kotlin**
+- Supports UIKit and SwiftUI on iOS and Fragments and Jetpack Compose on Android
 
 
 ## Installation
@@ -42,6 +43,26 @@ or
 ```sh
 yarn add @callstack/react-native-brownfield
 ```
+
+## Enabling New Architecture
+
+### Android
+Add the following to your `android/gradle.properties`:
+
+```
+# Enable new architecture
+newArchEnabled=true
+```
+
+### iOS
+Install cocoapods with the flag:
+
+```
+RCT_NEW_ARCH_ENABLED=1 pod install
+```
+
+> [!NOTE]
+> New Architecture is enabled by default from React Native 0.76
 
 ## Usage
 
@@ -79,6 +100,7 @@ ReactNativeBrownfield.popToNative(true);
 ```
 
 > NOTE: Those methods works only with native components provided by this library.
+
 
 ## Made with ❤️ at Callstack
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@
 
 - **Easily integrate** React Native with existing native app
 - Start React Native with **one method** and invoke code as soon as it's loaded
-- Reuse the same instance of React Native **bridge** between different components
+- Compatible with **both old and new React Native architecture**! 
+- Reuse the same instance of React Native **instance** between different components
 - Use predefined **native building blocks** - crafted for React Native
 - Disable and enable **native gestures and hardware buttons** from JavaScript
 - Works well with **any native navigation** pattern, as well as every React Native JavaScript based navigation

--- a/docs/JAVA.md
+++ b/docs/JAVA.md
@@ -10,7 +10,7 @@ Even though the library provides a first-class Java support, it's written in Kot
 buildscript {
     ext {
         ...
-        kotlinVersion = '1.3.31'
+        kotlinVersion = '2.0.21'
     }
     dependencies {
         ...
@@ -19,64 +19,14 @@ buildscript {
 }
 ```
 
-### Linking
-
-The library is meant to work with [auto linking](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md). In case you can't use this feature, please check out the following options:
-
-<details>
-<summary>react-native link</summary>
-Run the following command in your terminal:
-
-```bash
-  react-native link @callstack/react-native-brownfield
-```
-</details>
-
-<details>
-<summary>Manually link the library on Android</summary>
-
-#### `android/settings.gradle`
-```groovy
-include ':react-native-brownfield'
-project(':react-native-brownfield').projectDir = new File(rootProject.projectDir, '../node_modules/@callstack/react-native-brownfield/android')
-```
-
-#### `android/app/build.gradle`
-```groovy
-dependencies {
-   ...
-   implementation project(':react-native-brownfield')
-}
-```
-
-#### `android/app/src/main/.../MainApplication.java`
-On top, where imports are:
-
-```java
-import com.callstack.reactnativebrownfield.ReactNativeBrownfieldPackage;
-```
-
-Add the `ReactNativeBrownfieldPackage` class to your list of exported packages.
-
-```java
-@Override
-protected List<ReactPackage> getPackages() {
-    return Arrays.asList(
-            new MainReactPackage(),
-            new ReactNativeBrownfieldPackage()
-    );
-}
-```
-</details>
-
 ### API Reference
 
-#### ReactNativeBrownfield
+#### `ReactNativeBrownfield`
 
 You can import the object from:
 
 ```java
-  import com.callstack.reactnativebrownfield.ReactNativeBrownfield;
+import com.callstack.reactnativebrownfield.ReactNativeBrownfield;
 ```
 
 ---
@@ -91,58 +41,58 @@ Params:
 
 | Param                   | Required | Type                 | Description                                               |
 | ----------------------- | -------- | -------------------- | --------------------------------------------------------- |
-| application             | Yes      | Application          | Main application.                                         |
-| rnHost                  | No*      | ReactNativeHost      | An instance of [ReactNativeHost](https://bit.ly/2ZnwgnA). |
-| packages                | No*      | List<ReactPackage>   | List of your React Native Native modules.                 |
-| options                 | No*      | HashMap<String, Any> | Map of initial options. __Options listed below.__         |
+| application             | Yes      | `Application`          | Main application.                                         |
+| rnHost                  | No*      | `ReactNativeHost`      | An instance of [ReactNativeHost](https://bit.ly/2ZnwgnA). |
+| packages                | No*      | `List<ReactPackage>`   | List of your React Native Native modules.                 |
+| options                 | No*      | `HashMap<String, Any>` | Map of initial options. __Options listed below.__         |
 
 > * - Those fields aren't itself required, but at least one of them is. See examples below.
 
 Available options:
-- useDeveloperSupport: Boolean - Flag to use dev support.
-- packages: List<ReactPackage> - List of your React Native Native modules.
-- mainModuleName: String - Path to react native entry file.
+- `useDeveloperSupport`: `Boolean` - Flag to use dev support.
+- `packages`: `List<ReactPackage>` - List of your React Native Native modules.
+- `mainModuleName`: `String` - Path to react native entry file.
 
 Examples:
 
 ```java
-  private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {
-    @Override
-    public boolean getUseDeveloperSupport() {
-      return BuildConfig.DEBUG;
-    }
+private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {
+  @Override
+  public boolean getUseDeveloperSupport() {
+    return BuildConfig.DEBUG;
+  }
 
-    @Override
-    protected List<ReactPackage> getPackages() {
-      @SuppressWarnings("UnnecessaryLocalVariable")
-      List<ReactPackage> packages = new PackageList(this).getPackages();
-      // Packages that cannot be autolinked yet can be added manually here, for example:
-      // packages.add(new MyReactNativePackage());
-      return packages;
-    }
+  @Override
+  protected List<ReactPackage> getPackages() {
+    @SuppressWarnings("UnnecessaryLocalVariable")
+    List<ReactPackage> packages = new PackageList(this).getPackages();
+    // Packages that cannot be autolinked yet can be added manually here, for example:
+    // packages.add(new MyReactNativePackage());
+    return packages;
+  }
 
-    @Override
-    protected String getJSMainModuleName() {
-      return "index";
-    }
-  };
+  @Override
+  protected String getJSMainModuleName() {
+    return "index";
+  }
+};
 
-  ReactNativeBrownfield.initialize(this, mReactNativeHost);
+ReactNativeBrownfield.initialize(this, mReactNativeHost);
 ```
 
 ```java
-  List<ReactPackage> packages = new PackageList(this).getPackages();
+List<ReactPackage> packages = new PackageList(this).getPackages();
 
-  ReactNativeBrownfield.initialize(this, packages);
+ReactNativeBrownfield.initialize(this, packages);
 ```
 
 ```java
-  List<ReactPackage> packages = new PackageList(this).getPackages();
-  HashMap<String, Object> options = new HashMap<String, Any>();
-  options.put("packages", packages);
-  options.put("mainModuleName", "example/index");
+List<ReactPackage> packages = new PackageList(this).getPackages();
+HashMap<String, Object> options = new HashMap<String, Any>();
+options.put("packages", packages);
+options.put("mainModuleName", "example/index");
 
-  ReactNativeBrownfield.initialize(this, options);
+ReactNativeBrownfield.initialize(this, options);
 ```
 
 ---
@@ -154,7 +104,7 @@ A singleton that keeps an instance of ReactNativeBrownfield object.
 Examples: 
 
 ```java
-  ReactNativeBrownfield.getShared()
+ReactNativeBrownfield.getShared()
 ```
 
 ---
@@ -163,7 +113,7 @@ Examples:
 
 | Property        | Type            | Default        | Description                                               |
 | --------------- | --------------- | -------------- | --------------------------------------------------------- |
-| reactNativeHost | ReactNativeHost | null           | An instance of [ReactNativeHost](https://bit.ly/2ZnwgnA). |
+| reactNativeHost | `ReactNativeHost` | null           | An instance of [ReactNativeHost](https://bit.ly/2ZnwgnA). |
 
 ---
 
@@ -171,87 +121,64 @@ Examples:
 
 `startReactNative`
 
-Starts React Native, produces an instance of a bridge. You can use it to initialize React Native in your app.
+Starts React Native, produces an instance of react native. You can use it to initialize React Native in your app.
 
 Params:
 
 | Param                   | Required | Type          | Description                                           |
 | ----------------------- | -------- | ------------- | ----------------------------------------------------- |
-| startReactNative        | No       | Lambda        | Callback invoked after JS bundle is fully loaded.     |
+| startReactNative        | No       | `Lambda`        | Callback invoked after JS bundle is fully loaded.     |
 
 Examples:
 
 ```java
-    ReactNativeBrownfield.getShared().startReactNative();
+ReactNativeBrownfield.getShared().startReactNative();
 ```
 
 ```java
-    ReactNativeBrownfield.getShared().startReactNative(init -> {
-        Log.d("loaded", "React Native loaded");
-    });
+ReactNativeBrownfield.getShared().startReactNative(init -> {
+  Log.d("loaded", "React Native loaded");
+});
 ```
 
 ---
 
-#### ReactNativeActivity
+`createView`
 
-An activity rendering `ReactRootView` with a given module name.  It automatically uses an instance of a bridge created in `startReactNative` method. It works well with exposed JavaScript module. All the lifecycles are proxied to `ReactInstanceManager`.
-
-```java
-  import com.callstack.reactnativebrownfield.ReactNativeActivity;
-```
-
----
-
-**Statics:**
-
-`createReactActivityIntent`
-
-Creates an Intent with ReactNativeActivity, you can use it as a parameter in the `startActivity` method in order to push a new activity with embedded React Native.
+Creates a React Native view with a given module name. It automatically uses an instance of React Native created in `startReactNative` method. This is useful when embedding React Native views directly in your native layouts.
 
 Params:
 
-| Param                   | Required | Type                 | Description                                                 |
-| ----------------------- | -------- | ------------------------------------------- | ----------------------------------------------------------- |
-| context                 | Yes      | Context                                     | Application context.                                        |
-| moduleName              | Yes      | String                                      | Name of React Native component registered to `AppRegistry`. |
-| initialProps            | No       | Bundle || HashMap<String, *> || ReadableMap | Initial properties to be passed to React Native component.  |
+| Param          | Required | Type                | Description                                                 |
+| -------------- | -------- | ------------------- | ----------------------------------------------------------- |
+| context        | Yes      | `Context`           | Android context to create the view                          |
+| activity       | No       | `FragmentActivity`  | Activity hosting the view, used for lifecycle management    |
+| moduleName     | Yes      | `String`            | Name of React Native component registered to `AppRegistry`  |
+| launchOptions  | No       | `Bundle`            | Initial properties to be passed to React Native component   |
 
-Examples: 
+Returns:
+`FrameLayout` - A view containing the React Native component.
 
-```java
-  ReactNativeActivity.createReactActivityIntent(context, "ReactNative");
-```
-
-```java
-  Bundle bundle = new Bundle();
-  bundle.putInt("score", 12);
-
-  ReactNativeActivity.createReactActivityIntent(context, "ReactNative", bundle);
-```
+Examples:
 
 ```java
-  HashMap map = new HashMap<String, *>();
-  map.put("score", 12);
-
-  ReactNativeActivity.createReactActivityIntent(context, "ReactNative", map);
-```
-
-```java
-  WritableMap map = new WritableMap();
-  map.putInt("score", 12);
-
-  ReactNativeActivity.createReactActivityIntent(context, "ReactNative", map);
+// In a Fragment or Activity
+FrameLayout reactView = ReactNativeBrownfield.getShared().createView(
+  context,
+  activity,
+  "ReactNative"
+);
+container.addView(reactView);
 ```
 
 ---
 
-#### ReactNativeFragment
+#### `ReactNativeFragment`
 
-An fragment rendering `ReactRootView` with a given module name.  It automatically uses an instance of a bridge created in `startReactNative` method. It works well with exposed JavaScript module. All the lifecycles are proxied to `ReactInstanceManager`. It's the simplest way to embed React Native into your navigation stack.
+An fragment rendering `ReactRootView` with a given module name.  It automatically uses an instance of a React Native created in `startReactNative` method. It works well with exposed JavaScript module. All the lifecycles are proxied to `ReactInstanceManager`. It's the simplest way to embed React Native into your navigation stack.
 
 ```java
-  import com.callstack.reactnativebrownfield.ReactNativeFragment;
+import com.callstack.reactnativebrownfield.ReactNativeFragment;
 ```
 
 ---
@@ -260,46 +187,44 @@ An fragment rendering `ReactRootView` with a given module name.  It automaticall
 
 `createReactNativeFragment`
 
-Creates a Fragment with ReactNativeActivity, you can use it as a parameter in the `startActivity` method in order to push a new activity with embedded React Native.
+Creates a Fragment with `ReactNativeActivity`, you can use it as a parameter in the `startActivity` method in order to push a new activity with embedded React Native.
 
 Params:
 
 | Param                   | Required | Type                 | Description                                                 |
 | ----------------------- | -------- | ------------------------------------------- | ----------------------------------------------------------- |
-| moduleName              | Yes      | String                                      | Name of React Native component registered to `AppRegistry`. |
-| initialProps            | No       | Bundle || HashMap<String, *> || ReadableMap | Initial properties to be passed to React Native component.  |
+| moduleName              | Yes      | `String`                                      | Name of React Native component registered to `AppRegistry`. |
+| initialProps            | No       | `Bundle` \|\| `HashMap<String, *>` \|\| `ReadableMap` | Initial properties to be passed to React Native component.  |
 
 Examples: 
 
 ```java
-  ReactNativeFragment.createReactNativeFragment("ReactNative");
+ReactNativeFragment.createReactNativeFragment("ReactNative");
 ```
 
 ```java
-  Bundle bundle = new Bundle();
-  bundle.putInt("score", 12);
+Bundle bundle = new Bundle();
+bundle.putInt("score", 12);
 
-  ReactNativeFragment.createReactNativeFragment("ReactNative", bundle);
+ReactNativeFragment.createReactNativeFragment("ReactNative", bundle);
 ```
 
 ```java
-  HashMap map = new HashMap<String, *>();
-  map.put("score", 12);
+HashMap map = new HashMap<String, *>();
+map.put("score", 12);
 
-  ReactNativeFragment.createReactNativeFragment("ReactNative", map);
+ReactNativeFragment.createReactNativeFragment("ReactNative", map);
 ```
 
 ```java
-  WritableMap map = new WritableMap();
-  map.putInt("score", 12);
+WritableMap map = new WritableMap();
+map.putInt("score", 12);
 
-  ReactNativeFragment.createReactActivityIntent(context, "ReactNative", map);
+ReactNativeFragment.createReactNativeFragment("ReactNative", map);
 ```
 
 ---
 
 ### Example
 
-You can find an example app [here](../example/java).
-
-
+You can find an example app [here](../example/kotlin).

--- a/docs/KOTLIN.md
+++ b/docs/KOTLIN.md
@@ -2,58 +2,14 @@
 
 React Native Brownfield provides first-class support for Kotlin.
 
-### Linking
-
-The library is meant to work with [auto linking](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md). In case you can't use this feature, please check out the following options:
-
-<details>
-<summary>react-native link</summary>
-Run the following command in your terminal:
-
-```bash
-  react-native link @callstack/react-native-brownfield
-```
-</details>
-
-<details>
-<summary>Manually link the library on Android</summary>
-
-#### `android/settings.gradle`
-```groovy
-include ':react-native-brownfield'
-project(':react-native-brownfield').projectDir = new File(rootProject.projectDir, '../node_modules/@callstack/react-native-brownfield/android')
-```
-
-#### `android/app/build.gradle`
-```groovy
-dependencies {
-   ...
-   implementation project(':react-native-brownfield')
-}
-```
-
-#### `android/app/src/main/.../MainApplication.kt`
-On top, where imports are:
-
-```kotlin
-import com.callstack.reactnativebrownfield.ReactNativeBrownfieldPackage
-```
-
-Add the `ReactNativeBrownfieldPackage` class to your list of exported packages.
-
-```kotlin
-val packages = listOf<ReactPackage>(MainReactPackage(), ReactNativeBrownfieldPackage()) 
-```
-</details>
-
 ### API Reference
 
-#### ReactNativeBrownfield
+#### `ReactNativeBrownfield`
 
 You can import the object from:
 
 ```java
-  import com.callstack.reactnativebrownfield.ReactNativeBrownfield
+import com.callstack.reactnativebrownfield.ReactNativeBrownfield
 ```
 
 ---
@@ -68,52 +24,54 @@ Params:
 
 | Param                   | Required | Type                 | Description                                               |
 | ----------------------- | -------- | -------------------- | --------------------------------------------------------- |
-| application             | Yes      | Application          | Main application.                                         |
-| rnHost                  | No*      | ReactNativeHost      | An instance of [ReactNativeHost](https://bit.ly/2ZnwgnA). |
-| packages                | No*      | List<ReactPackage>   | List of your React Native Native modules.                 |
-| options                 | No*      | HashMap<String, Any> | Map of initial options. __Options listed below.__         |
+| application             | Yes      | `Application`          | Main application.                                         |
+| rnHost                  | No*      | `ReactNativeHost`      | An instance of [ReactNativeHost](https://bit.ly/2ZnwgnA). |
+| packages                | No*      | `List<ReactPackage>`   | List of your React Native Native modules.                 |
+| options                 | No*      | `HashMap<String, Any>` | Map of initial options. __Options listed below.__         |
 
 > * - Those fields aren't itself required, but at least one of them is. See examples below.
 
 Available options:
-- useDeveloperSupport: Boolean - Flag to use dev support.
-- packages: List<ReactPackage> - List of your React Native Native modules.
-- mainModuleName: String - Path to react native entry file.
+- `useDeveloperSupport`: `Boolean` - Flag to use dev support.
+- `packages`: `List<ReactPackage>` - List of your React Native Native modules.
+- `mainModuleName`: `String` - Path to react native entry file.
 
 Examples:
 
 ```kotlin
-  val mReactNativeHost = object : ReactNativeHost(application) {
-    override fun getUseDeveloperSupport(): Boolean {
-      return BuildConfig.DEBUG
-    }
+import com.callstack.reactnativebrownfield.ReactNativeBrownfield
 
-    override fun getPackages(): List<ReactPackage> {
-      return listOf<ReactPackage>(PackageList(this).getPackages())
-    }
-
-    override fun getJSMainModuleName(): String {
-      return "index"
-    }
+val mReactNativeHost = object : ReactNativeHost(application) {
+  override fun getUseDeveloperSupport(): Boolean {
+    return BuildConfig.DEBUG
   }
 
-  ReactNativeBrownfield.initialize(this, mReactNativeHost)
+  override fun getPackages(): List<ReactPackage> {
+    return listOf<ReactPackage>(PackageList(this).getPackages())
+  }
+
+  override fun getJSMainModuleName(): String {
+    return "index"
+  }
+}
+
+ReactNativeBrownfield.initialize(this, mReactNativeHost)
 ```
 
 ```kotlin
-  val packages = PackageList(this).getPackages()
+val packages = PackageList(this).getPackages()
 
-  ReactNativeBrownfield.initialize(this, packages)
+ReactNativeBrownfield.initialize(this, packages)
 ```
 
 ```kotlin
-  val packages = PackageList(this).getPackages()
-  val options = hashMapOf<String, Any>(
-    "packages" to packages, 
-    "mainModuleName" to "example/index"
-  )
+val packages = PackageList(this).getPackages()
+val options = hashMapOf<String, Any>(
+  "packages" to packages, 
+  "mainModuleName" to "example/index"
+)
 
-  ReactNativeBrownfield.initialize(this, options)
+ReactNativeBrownfield.initialize(this, options)
 ```
 
 ---
@@ -125,7 +83,7 @@ A singleton that keeps an instance of ReactNativeBrownfield object.
 Examples: 
 
 ```kotlin
-  ReactNativeBrownfield.shared
+ReactNativeBrownfield.shared
 ```
 
 ---
@@ -134,7 +92,7 @@ Examples:
 
 | Property        | Type            | Default        | Description                                               |
 | --------------- | --------------- | -------------- | --------------------------------------------------------- |
-| reactNativeHost | ReactNativeHost | null           | An instance of [ReactNativeHost](https://bit.ly/2ZnwgnA). |
+| reactNativeHost | `ReactNativeHost` | null           | An instance of [ReactNativeHost](https://bit.ly/2ZnwgnA). |
 
 ---
 
@@ -142,86 +100,74 @@ Examples:
 
 `startReactNative`
 
-Starts React Native, produces an instance of a bridge. You can use it to initialize React Native in your app.
+Starts React Native, produces an instance of React Native. You can use it to initialize React Native in your app.
 
 Params:
 
 | Param                   | Required | Type          | Description                                           |
 | ----------------------- | -------- | ------------- | ----------------------------------------------------- |
-| startReactNative        | No       | (loaded: boolean) -> Unit | Callback invoked after JS bundle is fully loaded.     |
+| startReactNative        | No       | `(loaded: boolean) -> Unit` | Callback invoked after JS bundle is fully loaded.     |
 
 Examples:
 
 ```kotlin
-    ReactNativeBrownfield.shared.startReactNative()
+ReactNativeBrownfield.shared.startReactNative()
 ```
 
 ```kotlin
-    ReactNativeBrownfield.shared.startReactNative {
-        Log.d("loaded", "React Native loaded");
-    }
+ReactNativeBrownfield.shared.startReactNative {
+  Log.d("loaded", "React Native loaded");
+}
 ```
 
 ---
 
-#### ReactNativeActivity
+`createView`
 
-An activity rendering `ReactRootView` with a given module name.  It automatically uses an instance of a bridge created in `startReactNative` method. It works well with exposed JavaScript module. All the lifecycles are proxied to `ReactInstanceManager`.
-
-```kotlin
-  import com.callstack.reactnativebrownfield.ReactNativeActivity
-```
-
----
-
-**Statics:**
-
-`createReactActivityIntent`
-
-Creates an Intent with ReactNativeActivity, you can use it as a parameter in the `startActivity` method in order to push a new activity with embedded React Native.
+Creates a React Native view with a given module name. It automatically uses an instance of React Native created in `startReactNative` method. This is useful when embedding React Native views directly in your native layouts or Jetpack Compose UI.
 
 Params:
 
-| Param                   | Required | Type                 | Description                                                 |
-| ----------------------- | -------- | ------------------------------------------- | ----------------------------------------------------------- |
-| context                 | Yes      | Context                                     | Application context.                                        |
-| moduleName              | Yes      | String                                      | Name of React Native component registered to `AppRegistry`. |
-| initialProps            | No       | Bundle || HashMap<String, *> || ReadableMap | Initial properties to be passed to React Native component.  |
+| Param          | Required | Type                | Description                                                 |
+| -------------- | -------- | ------------------- | ----------------------------------------------------------- |
+| context        | Yes      | `Context`           | Android context to create the view                          |
+| activity       | No       | `FragmentActivity`  | Activity hosting the view, used for lifecycle management    |
+| moduleName     | Yes      | `String`            | Name of React Native component registered to `AppRegistry`  |
+| launchOptions  | No       | `Bundle`            | Initial properties to be passed to React Native component   |
 
-Examples: 
+Returns:
+`FrameLayout` - A view containing the React Native component.
+
+Examples:
 
 ```kotlin
-  ReactNativeActivity.createReactActivityIntent(context, "ReactNative")
+// In a Fragment or Activity
+val reactView = ReactNativeBrownfield.shared.createView(
+  context,
+  activity,
+  "ReactNative"
+)
+container.addView(reactView)
 ```
 
 ```kotlin
-  val bundle = Bundle()
-  bundle.putInt("score", 12)
-
-  ReactNativeActivity.createReactActivityIntent(context, "ReactNative", bundle)
-```
-
-```kotlin
-  val map =  hasnMapOf<String, *>("score" to 12)
-
-  ReactNativeActivity.createReactActivityIntent(context, "ReactNative", map)
-```
-
-```kotlin
-  val map = WritableMap();
-  map.putInt("score", 12);
-
-  ReactNativeActivity.createReactActivityIntent(context, "ReactNative", map)
+// With Jetpack Compose
+AndroidView(
+  factory = { context ->
+    ReactNativeBrownfield.shared.createView(context, fragmentActivity, "ReactNative")
+  },
+  modifier = Modifier.fillMaxSize()
+)
 ```
 
 ---
 
-#### ReactNativeFragment
+#### `ReactNativeFragment`
 
-An fragment rendering `ReactRootView` with a given module name.  It automatically uses an instance of a bridge created in `startReactNative` method. It works well with exposed JavaScript module. All the lifecycles are proxied to `ReactInstanceManager`. It's the simplest way to embed React Native into your navigation stack.
+An fragment rendering `ReactRootView` with a given module name. It automatically uses a instance of React Native created in `startReactNative` method. It works well with exposed JavaScript module. All the lifecycles are proxied to `ReactInstanceManager`. It's the simplest way to embed React Native into your navigation stack.
 
 ```kotlin
-  import com.callstack.reactnativebrownfield.ReactNativeFragment
+import com.callstack.reactnativebrownfield.ReactNativeFragment
 ```
 
 ---
@@ -230,45 +176,43 @@ An fragment rendering `ReactRootView` with a given module name.  It automaticall
 
 `createReactNativeFragment`
 
-Creates a Fragment with ReactNativeActivity, you can use it as a parameter in the `startActivity` method in order to push a new activity with embedded React Native.
+Creates a Fragment with `ReactNativeActivity`, you can use it as a parameter in the `startActivity` method in order to push a new activity with embedded React Native.
 
 Params:
 
 | Param                   | Required | Type                 | Description                                                 |
 | ----------------------- | -------- | ------------------------------------------- | ----------------------------------------------------------- |
-| moduleName              | Yes      | String                                      | Name of React Native component registered to `AppRegistry`. |
-| initialProps            | No       | Bundle || HashMap<String, *> || ReadableMap | Initial properties to be passed to React Native component.  |
+| moduleName              | Yes      | `String`                                      | Name of React Native component registered to `AppRegistry`. |
+| initialProps            | No       | `Bundle` \|\| `HashMap<String, *>` \|\| `ReadableMap` | Initial properties to be passed to React Native component.  |
 
 Examples: 
 
 ```kotlin
-  ReactNativeFragment.createReactNativeFragment("ReactNative")
+ReactNativeFragment.createReactNativeFragment("ReactNative")
 ```
 
 ```kotlin
-  val bundle = new Bundle()
-  bundle.putInt("score", 12)
+val bundle = Bundle()
+bundle.putInt("score", 12)
 
-  ReactNativeFragment.createReactNativeFragment("ReactNative", bundle)
+ReactNativeFragment.createReactNativeFragment("ReactNative", bundle)
 ```
 
 ```kotlin
-  val map = hashMapOf<String, *>("score" to 12)
+val map = hashMapOf<String, *>("score" to 12)
 
-  ReactNativeFragment.createReactNativeFragment("ReactNative", map)
+ReactNativeFragment.createReactNativeFragment("ReactNative", map)
 ```
 
 ```kotlin
-  val map = WritableMap()
-  map.putInt("score", 12)
+val map = WritableMap()
+map.putInt("score", 12)
 
-  ReactNativeFragment.createReactActivityIntent(context, "ReactNative", map)
+ReactNativeFragment.createReactNativeFragment("ReactNative", map)
 ```
 
 ---
 
 ### Example
 
-You can find an example app [here](../example/java).
-
-
+You can find an example app [here](../example/kotlin).

--- a/docs/OBJECTIVE_C.md
+++ b/docs/OBJECTIVE_C.md
@@ -2,44 +2,6 @@
 
 React Native Brownfield provides first-class support for Objective-C.
 
-### Linking
-
-The library is meant to work with [auto linking](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md). In case you can't use this feature, please check out the following options:
-
-<details>
-<summary>react-native link</summary>
-Run the following command in your terminal:
-
-```bash
-  react-native link @callstack/react-native-brownfield
-```
-</details>
-
-<details>
-<summary>CocoaPods</summary>
-Add the following line to your `Podfile`:
-
-```ruby
-  pod 'ReactNativeBrownfield', :path => '../node_modules/@callstack/react-native-brownfield'
-```
-</details>
-
-<details>
-<summary>Manually link the library on iOS</summary>
-
-### `Open project.xcodeproj in Xcode`
-
-Drag `ReactNativeBrownfield.xcodeproj` to your project on Xcode (usually under the Libraries group on Xcode):
-
-![xcode-add](https://facebook.github.io/react-native/docs/assets/AddToLibraries.png)
-
-### Link `libReactNativeBrownfield.a` binary with libraries
-
-Click on your main project file (the one that represents the `.xcodeproj`) select `Build Phases` and drag the static library from the `Products` folder inside the Library you are importing to `Link Binary With Libraries` (or use the `+` sign and choose library from the list):
-
-![xcode-link](https://facebook.github.io/react-native/docs/assets/AddToBuildPhases.png)
-</details>
-
 ### API Reference
 
 #### ReactNativeBrownfield
@@ -47,7 +9,7 @@ Click on your main project file (the one that represents the `.xcodeproj`) selec
 You can import the object from:
 
 ```objc
-  #import <ReactNativeBrownfield/ReactNativeBrownfield.h>
+#import <ReactNativeBrownfield/ReactNativeBrownfield.h>
 ```
 
 ---
@@ -61,7 +23,7 @@ A singleton that keeps an instance of `ReactNativeBrownfield` object.
 Examples:
 
 ```objc
-  [ReactNativeBrownfield shared]
+[ReactNativeBrownfield shared]
 ```
 
 ---
@@ -81,7 +43,7 @@ Examples:
 
 `startReactNative`
 
-Starts React Native, produces an instance of a bridge. You can use it to initialize React Native in your app.
+Starts React Native, produces an instance of React Native. You can use it to initialize React Native in your app.
 
 Params:
 
@@ -93,19 +55,19 @@ Params:
 Examples:
 
 ```objc
-    [[ReactNativeBrownfield shared] startReactNative];
+[[ReactNativeBrownfield shared] startReactNative];
 ```
 
 ```objc
-    [[ReactNativeBrownfield shared] startReactNative:^(void){
-        NSLog(@"React Native started");
-    }];
+[[ReactNativeBrownfield shared] startReactNative:^(void){
+    NSLog(@"React Native started");
+}];
 ```
 
 ```objc
-    [[ReactNativeBrownfield shared] startReactNative:^(void){
-        NSLog(@"React Native started");
-    }, launchOptions];
+[[ReactNativeBrownfield shared] startReactNative:^(void){
+    NSLog(@"React Native started");
+}, launchOptions];
 ```
 
 ---
@@ -117,7 +79,7 @@ A view controller that's rendering React Native view within its bounds. It autom
 You can import it from:
 
 ```objc
-  #import <ReactNativeBrownfield/ReactNativeViewController.h>
+#import <ReactNativeBrownfield/ReactNativeViewController.h>
 ```
 
 ---
@@ -134,10 +96,10 @@ You can import it from:
 Examples:
 
 ```objc
-  [[ReactNativeViewController alloc] initWithModuleName:@"ReactNative"]
+[[ReactNativeViewController alloc] initWithModuleName:@"ReactNative"]
 ```
 
 ```objc
-  [[ReactNativeViewController alloc] initWithModuleName:@"ReactNative" andInitialProperties:@{@"score": @12}]
+[[ReactNativeViewController alloc] initWithModuleName:@"ReactNative" andInitialProperties:@{@"score": @12}]
 ```
 

--- a/docs/SWIFT.md
+++ b/docs/SWIFT.md
@@ -2,44 +2,6 @@
 
 React Native Brownfield provides first-class support for Swift. 
 
-### Linking
-
-The library is meant to work with [auto linking](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md). In case you can't use this feature, please check out the following options:
-
-<details>
-<summary>react-native link</summary>
-Run the following command in your terminal:
-
-```bash
-  react-native link @callstack/react-native-brownfield
-```
-</details>
-
-<details>
-<summary>CocoaPods</summary>
-Add the following line to your `Podfile`:
-
-```ruby
-  pod 'ReactNativeBrownfield', :path => '../node_modules/@callstack/react-native-brownfield'
-```
-</details>
-
-<details>
-<summary>Manually link the library on iOS</summary>
-
-### `Open project.xcodeproj in Xcode`
-
-Drag `ReactNativeBrownfield.xcodeproj` to your project on Xcode (usually under the Libraries group on Xcode):
-
-![xcode-add](https://facebook.github.io/react-native/docs/assets/AddToLibraries.png)
-
-### Link `libReactNativeBrownfield.a` binary with libraries
-
-Click on your main project file (the one that represents the `.xcodeproj`) select `Build Phases` and drag the static library from the `Products` folder inside the Library you are importing to `Link Binary With Libraries` (or use the `+` sign and choose library from the list):
-
-![xcode-link](https://facebook.github.io/react-native/docs/assets/AddToBuildPhases.png)
-</details>
-
 ### API Reference
 
 #### `ReactNativeBrownfield`
@@ -47,7 +9,7 @@ Click on your main project file (the one that represents the `.xcodeproj`) selec
 You can import the object from:
 
 ```swift
-  import ReactNativeBrownfield
+import ReactNativeBrownfield
 ```
 
 ---
@@ -61,7 +23,7 @@ A singleton that keeps an instance of `ReactNativeBrownfield` object.
 Examples:
 
 ```swift
-  ReactNativeBrownfield.shared
+ReactNativeBrownfield.shared
 ```
 
 ---
@@ -93,19 +55,19 @@ Params:
 Examples:
 
 ```swift
-    ReactNativeBrownfield.shared.startReactNative()
+ReactNativeBrownfield.shared.startReactNative()
 ```
 
 ```swift
-   ReactNativeBrownfield.shared.startReactNative(onBundleLoaded: {
-     print("React Native started")
-   })
+ReactNativeBrownfield.shared.startReactNative(onBundleLoaded: {
+  print("React Native started")
+})
 ```
 
 ```swift
-    ReactNativeBrownfield.shared.startReactNative(onBundleLoaded: {
-      print("React Native started")
-    }, launchOptions: launchOptions)
+ReactNativeBrownfield.shared.startReactNative(onBundleLoaded: {
+  print("React Native started")
+}, launchOptions: launchOptions)
 ```
 
 ---
@@ -205,7 +167,7 @@ A view controller that's rendering React Native view within its bounds. It autom
 You can import it from:
 
 ```swift
-  import ReactNativeBrownfield
+import ReactNativeBrownfield
 ```
 
 ---
@@ -222,11 +184,11 @@ You can import it from:
 Examples:
 
 ```swift
-  ReactNativeViewController(moduleName: "ReactNative")
+ReactNativeViewController(moduleName: "ReactNative")
 ```
 
 ```swift
-  ReactNativeViewController(moduleName: "ReactNative", initialProperties: ["score": 12])
+ReactNativeViewController(moduleName: "ReactNative", initialProperties: ["score": 12])
 ```
 
 ---
@@ -238,7 +200,7 @@ A SwiftUI view that wraps the `ReactNativeViewController`, making it easy to int
 You can import it from:
 
 ```swift
-  import ReactNativeBrownfield
+import ReactNativeBrownfield
 ```
 
 ---
@@ -255,11 +217,11 @@ You can import it from:
 Examples:
 
 ```swift
-  ReactNativeView(moduleName: "ReactNative")
+ReactNativeView(moduleName: "ReactNative")
 ```
 
 ```swift
-  ReactNativeView(moduleName: "ReactNative", initialProperties: ["score": 12])
+ReactNativeView(moduleName: "ReactNative", initialProperties: ["score": 12])
 ```
 
 Usage with SwiftUI navigation:


### PR DESCRIPTION
### Summary

This PR updates the docs to: 

- Mention both old and new architecture support
- Remove manual auto-linking instructions (it's no longer relevant)
- Change wording from a "bridge" to instance (since we have bridgeless mode in new arch)
- Document createView() API with Jetpack compose integration
- Fix indentation and add backticks

### Test plan

Read the docs