### PR TITLE
feat: add RNSourceSets handler

### DIFF
--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/plugin/RNBrownfieldPlugin.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/plugin/RNBrownfieldPlugin.kt
@@ -30,6 +30,7 @@ class RNBrownfieldPlugin
             verifyAndroidPluginApplied(project)
 
             initializers(project)
+            RNSourceSets.configure(project, extension)
             projectConfigurations.setup()
             registerRClassTransformer()
 

--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/plugin/RNSourceSets.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/plugin/RNSourceSets.kt
@@ -1,0 +1,91 @@
+package com.callstack.react.brownfield.plugin
+
+import com.android.build.gradle.LibraryExtension
+import com.callstack.react.brownfield.utils.Extension
+import org.gradle.api.Project
+import org.gradle.api.file.Directory
+import org.gradle.api.tasks.Copy
+
+object RNSourceSets {
+    private lateinit var project: Project
+    private lateinit var extension: Extension
+    private lateinit var androidExtension: LibraryExtension
+    private lateinit var appProject: Project
+    private lateinit var appBuildDir: Directory
+    private lateinit var moduleBuildDir: Directory
+
+    fun configure(
+        project: Project,
+        extension: Extension,
+    ) {
+        if (project.name == "example-android-library") {
+            return
+        }
+        this.project = project
+        this.extension = extension
+
+        androidExtension = RNSourceSets.project.extensions.getByName("android") as LibraryExtension
+        appProject = RNSourceSets.project.rootProject.project(RNSourceSets.extension.appProjectName)
+        appBuildDir = appProject.layout.buildDirectory.get()
+        moduleBuildDir = RNSourceSets.project.layout.buildDirectory.get()
+
+        configureSourceSets()
+        configureTasks()
+    }
+
+    private fun configureSourceSets() {
+        androidExtension.sourceSets.getByName("main") {
+            it.assets.srcDirs("$appBuildDir/generated/assets/createBundleReleaseJsAndAssets")
+            it.res.srcDirs("$appBuildDir/generated/res/createBundleReleaseJsAndAssets")
+            it.java.srcDirs("$moduleBuildDir/generated/autolinking/src/main/java")
+        }
+
+        androidExtension.sourceSets.getByName("release") {
+            it.jniLibs.srcDirs("libsRelease")
+        }
+
+        androidExtension.sourceSets.getByName("debug") {
+            it.jniLibs.srcDirs("libsDebug")
+        }
+    }
+
+    private fun configureTasks() {
+        val projectName = project.name
+        val appProjectName = appProject.name
+
+        project.tasks.register("copyAutolinkingSources", Copy::class.java) {
+            val path = "generated/autolinking/src/main/java"
+            it.dependsOn(":$appProjectName:generateAutolinkingPackageList")
+            it.from("$appBuildDir/$path")
+            it.into("$moduleBuildDir/$path")
+        }
+
+        androidExtension.buildTypes.forEach { buildType ->
+            val capitalisedBuildType = buildType.name.replaceFirstChar { it.titlecase() }
+            val codegenTaskName = "generateCodegenSchemaFromJavaScript"
+            val strippedNativeLibsPath = "$appBuildDir/intermediates/stripped_native_libs"
+            val strippedDebugSymbolsPath = "strip${capitalisedBuildType}DebugSymbols/out/lib"
+
+            val copyLibTask =
+                project.tasks.register("copy${capitalisedBuildType}LibSources", Copy::class.java) {
+                    it.dependsOn(":$appProjectName:$codegenTaskName")
+                    it.dependsOn(":$appProjectName:strip${capitalisedBuildType}DebugSymbols")
+                    it.dependsOn(":$projectName:$codegenTaskName")
+
+                    it.from(
+                        "$strippedNativeLibsPath/${buildType.name}/$strippedDebugSymbolsPath",
+                    )
+                    it.into(project.rootProject.file("$projectName/libs$capitalisedBuildType"))
+                    it.include("**/libappmodules.so", "**/libreact_codegen_*.so")
+                }
+
+            project.tasks.named("preBuild").configure {
+                it.dependsOn("copyAutolinkingSources")
+                it.dependsOn(copyLibTask)
+                if (capitalisedBuildType == "Release") {
+                    it.dependsOn(":${appProject.name}:createBundleReleaseJsAndAssets")
+                }
+            }
+        }
+    }
+}

--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/plugin/RNSourceSets.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/plugin/RNSourceSets.kt
@@ -18,6 +18,12 @@ object RNSourceSets {
         project: Project,
         extension: Extension,
     ) {
+        /**
+         * Do not configure sourceSets for our example library.
+         * The reason is that we expect some RN specific tasks to
+         * be present on the consuming library, which is not the case
+         * with our example library.
+         */
         if (project.name == "example-android-library") {
             return
         }

--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/utils/Extension.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/utils/Extension.kt
@@ -21,4 +21,12 @@ open class Extension {
      * Default value is true
      */
     var resolveLocalDependencies = true
+
+    /**
+     * Name of the module using `com.android.application`
+     * For eg, app
+     *
+     * Default value is `app`
+     */
+    var appProjectName = "app"
 }


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

As of yet, the end-user of the `brownfield-gradle-plugin` is expected to add `sourceSets` and the tasks on which those `sourceSets` depends. This is required to load the AAR correctly in the App.

With these changes, the end-user do not need to make any changes and are fine by just installing and configuring the `brownfield-gradle-plugin`.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

Tested it locally in a brownfield RN app.