### PR TITLE
chore: bump plugin version

### DIFF
--- a/gradle-plugins/react/brownfield/gradle.properties
+++ b/gradle-plugins/react/brownfield/gradle.properties
@@ -1,6 +1,6 @@
 PROJECT_ID=com.callstack.react.brownfield
 ARTIFACT_ID=brownfield-gradle-plugin
-VERSION=0.1.0
+VERSION=0.2.0
 GROUP=com.callstack.react
 IMPLEMENTATION_CLASS=com.callstack.react.brownfield.plugin.RNBrownfieldPlugin
 


### PR DESCRIPTION
# Summary

Bumps plugin version to `0.2.0`, which is already released
