### PR TITLE
fix: Cannot find 'bundlePath' in scope on Release build

### DIFF
--- a/ios/ReactNativeBrownfield.swift
+++ b/ios/ReactNativeBrownfield.swift
@@ -5,6 +5,7 @@ internal import ReactAppDependencyProvider
 
 class ReactNativeBrownfieldDelegate: RCTDefaultReactNativeFactoryDelegate {
   var entryFile = "index"
+  var bundlePath = "main.jsbundle"
   // MARK: - RCTReactNativeFactoryDelegate Methods
   
   override func sourceURL(for bridge: RCTBridge) -> URL? {
@@ -48,7 +49,11 @@ class ReactNativeBrownfieldDelegate: RCTDefaultReactNativeFactoryDelegate {
    * Path to JavaScript bundle file.
    * Default value: "main.jsbundle"
    */
-  @objc public var bundlePath: String = "main.jsbundle"
+  @objc public var bundlePath: String = "main.jsbundle" {
+    didSet {
+      delegate.bundlePath = bundlePath
+    }
+  }
   /**
    * React Native factory instance created when starting React Native.
    * Default value: nil


### PR DESCRIPTION
Resolves https://github.com/callstack/react-native-brownfield/issues/109

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

You won't be able to make non-debug builds with the missing `bundlePath` variable

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
