### PR TITLE
feat(ios): allow overriding the bundle instance

### DIFF
--- a/ios/ReactNativeBrownfield.swift
+++ b/ios/ReactNativeBrownfield.swift
@@ -6,6 +6,7 @@ internal import ReactAppDependencyProvider
 class ReactNativeBrownfieldDelegate: RCTDefaultReactNativeFactoryDelegate {
   var entryFile = "index"
   var bundlePath = "main.jsbundle"
+  var bundle = Bundle.main
   // MARK: - RCTReactNativeFactoryDelegate Methods
   
   override func sourceURL(for bridge: RCTBridge) -> URL? {
@@ -21,7 +22,7 @@ class ReactNativeBrownfieldDelegate: RCTDefaultReactNativeFactoryDelegate {
     let resourceName = withoutLast.joined()
     let fileExtension = resourceURLComponents.last ?? ""
     
-    return Bundle.main.url(forResource: resourceName, withExtension: fileExtension)
+    return bundle.url(forResource: resourceName, withExtension: fileExtension)
 #endif
   }
 }
@@ -52,6 +53,15 @@ class ReactNativeBrownfieldDelegate: RCTDefaultReactNativeFactoryDelegate {
   @objc public var bundlePath: String = "main.jsbundle" {
     didSet {
       delegate.bundlePath = bundlePath
+    }
+  }
+  /**
+   * Bundle instance to lookup the JavaScript bundle.
+   * Default value: Bundle.main
+   */
+  @objc public var bundle: Bundle = Bundle.main {
+    didSet {
+      delegate.bundle = bundle
     }
   }
   /**


### PR DESCRIPTION
### Summary

`bundleURL` on iOS was using `Bundle.main` to retrieve the `main.jsbundle` file. [Bundle.main](https://developer.apple.com/documentation/foundation/bundle/main) returns the Bundle instance of the target that executes the code. This means the generated `main.jsbundle` file should always be placed at `ReactBrownfield` framework's bundle for it to work.

This PR makes it possible to change the bundle instance, so the framework target that uses `@_exported` to reexport rn-brownfield can also own the `main.jsbundle` file.

### Test plan

1. Compile react-native-brownfield as a framework
2. Update the bundle insntance to point to a different target
3. Place your `main.jsbundle` to that different target
4. Make sure the js bundle is resolved properly.
