### PR TITLE
feat: add support for react-native entry point for versions starting from 0.80.0

### DIFF
--- a/gradle-plugins/react/brownfield/build.gradle.kts
+++ b/gradle-plugins/react/brownfield/build.gradle.kts
@@ -1,5 +1,3 @@
-import java.util.Properties
-
 plugins {
     alias(libs.plugins.kotlinJvm)
     `java-gradle-plugin`
@@ -124,4 +122,3 @@ tasks.javadoc {
         source = "8"
     }
 }
-

--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/exceptions/NameSpaceNotFound.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/exceptions/NameSpaceNotFound.kt
@@ -1,0 +1,4 @@
+package com.callstack.react.brownfield.exceptions
+
+class NameSpaceNotFound(message: String) :
+    RuntimeException(message)

--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/plugin/RNSourceSets.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/plugin/RNSourceSets.kt
@@ -68,15 +68,12 @@ object RNSourceSets {
         path: String,
     ) {
         val rnEntryPointTaskName = "generateReactNativeEntryPoint"
-        val rnEntryPointTask = appProject.tasks.named(rnEntryPointTaskName)
 
         /**
          * If `generateReactNativeEntryPoint` task does not exist, we early return. It means
          * the consumer library is running on RN version < 0.80
          */
-        if (!rnEntryPointTask.isPresent) {
-            return
-        }
+        val rnEntryPointTask = appProject.tasks.findByName(rnEntryPointTaskName) ?: return
 
         task.dependsOn(rnEntryPointTask)
         val sourceFile = File(moduleBuildDir.toString(), "$path/com/facebook/react/ReactNativeApplicationEntryPoint.java")

--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/plugin/RNSourceSets.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/plugin/RNSourceSets.kt
@@ -1,10 +1,13 @@
 package com.callstack.react.brownfield.plugin
 
 import com.android.build.gradle.LibraryExtension
+import com.callstack.react.brownfield.exceptions.NameSpaceNotFound
 import com.callstack.react.brownfield.utils.Extension
 import org.gradle.api.Project
+import org.gradle.api.Task
 import org.gradle.api.file.Directory
 import org.gradle.api.tasks.Copy
+import java.io.File
 
 object RNSourceSets {
     private lateinit var project: Project
@@ -55,6 +58,46 @@ object RNSourceSets {
         }
     }
 
+    private fun getLibraryNameSpace(): String {
+        val nameSpace = androidExtension.namespace
+        return nameSpace ?: throw NameSpaceNotFound("namespace must be defined in your android library build.gradle")
+    }
+
+    private fun patchRNEntryPoint(
+        task: Task,
+        path: String,
+    ) {
+        val rnEntryPointTaskName = "generateReactNativeEntryPoint"
+        val rnEntryPointTask = appProject.tasks.named(rnEntryPointTaskName)
+
+        /**
+         * If `generateReactNativeEntryPoint` task does not exist, we early return. It means
+         * the consumer library is running on RN version < 0.80
+         */
+        if (!rnEntryPointTask.isPresent) {
+            return
+        }
+
+        task.dependsOn(rnEntryPointTask)
+        val sourceFile = File(moduleBuildDir.toString(), "$path/com/facebook/react/ReactNativeApplicationEntryPoint.java")
+        task.doLast {
+            if (sourceFile.exists()) {
+                var content = sourceFile.readText()
+                val nameSpace = getLibraryNameSpace()
+
+                /**
+                 * We use look-ahead regex to replace any occurrences with Build.Config referenced via the old(app) package
+                 *
+                 * \b[\w.]+ → matches the old package
+                 * (?=\.BuildConfig) → only if it’s immediately followed by that suffix
+                 */
+                val regex = Regex("""\b[\w.]+(?=\.BuildConfig)""")
+                content = content.replace(regex, nameSpace)
+                sourceFile.writeText(content)
+            }
+        }
+    }
+
     private fun configureTasks() {
         val projectName = project.name
         val appProjectName = appProject.name
@@ -64,6 +107,8 @@ object RNSourceSets {
             it.dependsOn(":$appProjectName:generateAutolinkingPackageList")
             it.from("$appBuildDir/$path")
             it.into("$moduleBuildDir/$path")
+
+            patchRNEntryPoint(it, path)
         }
 
         androidExtension.buildTypes.forEach { buildType ->


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

With react-native@0.80.0, a new generated class was added by `react-native-gradle-plugin`. This class contains the `app` package name. Since we copy and paste the contents of autolinking generated dir, the package name in `ReactNativeApplicationEntryPoint.java` does not reflect the package name for `library`. To achieve this, we replace the occurrences of app package name with library package name. So technically, we patch the copied `ReactNativeApplicationEntryPoint` in autolinking dir of the library.

The above is achieved via `patchRNEntryPoint` method. If the task `generateReactNativeEntryPoint` does not exist, we early return, which indicates a react-native version < 0.80.0

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

Tested this on both react-native@0.79.0 and react-native@0.80.0. - 🟢 