### PR TITLE
feat: migrate to  react delegate wrapper

### DIFF
--- a/android/src/main/java/com/callstack/reactnativebrownfield/ReactDelegateWrapper.kt
+++ b/android/src/main/java/com/callstack/reactnativebrownfield/ReactDelegateWrapper.kt
@@ -1,0 +1,31 @@
+package com.callstack.reactnativebrownfield
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import com.facebook.react.ReactDelegate
+import com.facebook.react.ReactHost
+import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler
+
+class ReactDelegateWrapper(
+    private val activity: ComponentActivity?,
+    private val reactHost: ReactHost,
+    moduleName: String,
+    launchOptions: Bundle?
+): ReactDelegate(activity, reactHost, moduleName, launchOptions){
+    private lateinit var hardwareBackHandler: () -> Unit
+    private val backBtnHandler = DefaultHardwareBackBtnHandler {
+        hardwareBackHandler()
+    }
+
+    /**
+     * This is invoked when there is no more RN Stack to pop.
+     * What it means that this is now the initial RN screen.
+     */
+    fun setHardwareBackHandler(backHandler: () -> Unit) {
+        hardwareBackHandler = backHandler
+    }
+
+    override fun onHostResume() {
+        reactHost.onHostResume(activity, backBtnHandler)
+    }
+}

--- a/android/src/main/java/com/callstack/reactnativebrownfield/ReactNativeFragment.kt
+++ b/android/src/main/java/com/callstack/reactnativebrownfield/ReactNativeFragment.kt
@@ -118,7 +118,7 @@ class ReactNativeFragment : ReactFragment(), PermissionAwareActivity {
           .didDoubleTapR(keyCode, it)
       }
       if (didDoubleTapR == true) {
-        ReactNativeBrownfield.shared.reactNativeHost.reactInstanceManager.devSupportManager.handleReloadJS()
+        reactDelegate.reload()
         handled = true
       }
     }

--- a/example/kotlin/app/src/main/java/com/callstack/kotlinexample/MainActivity.kt
+++ b/example/kotlin/app/src/main/java/com/callstack/kotlinexample/MainActivity.kt
@@ -22,9 +22,8 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.callstack.reactnativebrownfield.ReactNativeBrownfield
-import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler
 
-class MainActivity : AppCompatActivity(), DefaultHardwareBackBtnHandler {
+class MainActivity : AppCompatActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
 
@@ -58,10 +57,6 @@ class MainActivity : AppCompatActivity(), DefaultHardwareBackBtnHandler {
         }
       }
     }
-  }
-
-  override fun invokeDefaultOnBackPressed() {
-    super.onBackPressed()
   }
 
   fun startReactNativeFragment() {

--- a/example/kotlin/app/src/main/java/com/callstack/kotlinexample/ReactNativeFragmentActivity.kt
+++ b/example/kotlin/app/src/main/java/com/callstack/kotlinexample/ReactNativeFragmentActivity.kt
@@ -4,12 +4,8 @@ import android.os.Bundle
 import android.view.KeyEvent
 import androidx.appcompat.app.AppCompatActivity
 import com.callstack.reactnativebrownfield.ReactNativeFragment
-import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler
 
-class ReactNativeFragmentActivity : AppCompatActivity(), DefaultHardwareBackBtnHandler {
-  override fun invokeDefaultOnBackPressed() {
-    super.onBackPressed()
-  }
+class ReactNativeFragmentActivity : AppCompatActivity() {
 
   public override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -30,14 +26,5 @@ class ReactNativeFragmentActivity : AppCompatActivity(), DefaultHardwareBackBtnH
       handled = activeFragment.onKeyUp(keyCode, event)
     }
     return handled || super.onKeyUp(keyCode, event)
-  }
-
-  override fun onBackPressed() {
-    val activeFragment = supportFragmentManager.findFragmentById(R.id.container_main)
-    if (activeFragment is ReactNativeFragment) {
-      activeFragment.onBackPressed(this)
-    } else {
-      super.onBackPressed()
-    }
   }
 }


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

This PR migrates the existing implementation from `ReactDelegate` to `ReactDelegateWrapper`. The latter is a custom class that is created and it extends `ReactDelegate`. We follow this approach for two reasons:

- The calling Activity in the native App does not need to implement `DefaultHardwareBackBtnListener` (a react-native internal interface)
  - A native App should not need to directly interface with RN core.
- With this approach, we can pop the JS RN screens on hardware back button press


### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->


https://github.com/user-attachments/assets/4f9e5159-1d42-45f4-9cb8-a4eddc164097


