### PR TITLE
fix: pass initial props for SwiftUI views

### DIFF
--- a/ios/ReactNativeView.swift
+++ b/ios/ReactNativeView.swift
@@ -8,7 +8,10 @@ struct ReactNativeViewRepresentable: UIViewControllerRepresentable {
   var initialProperties: [String: Any] = [:]
 
   func makeUIViewController(context: Context) -> UIViewController {
-    return ReactNativeViewController(moduleName: moduleName)
+    return ReactNativeViewController(
+      moduleName: moduleName,
+      initialProperties: initialProperties
+    )
   }
 
   func updateUIViewController(_ uiViewController: UIViewController, context: Context) {}


### PR DESCRIPTION
### Summary

This PR passes initial props for SwiftUI views, closing: #117