### PR TITLE
Fix comment syntax in README.md for Android instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import com.callstack.rnbrownfield.RNViewFactory # exposed by RN app framework
+import com.callstack.rnbrownfield.RNViewFactory // exposed by RN app framework
 
 class RNAppFragment : Fragment() {
     override fun onCreateView(


### PR DESCRIPTION
### Summary

`#` is not valid for a comment in kotlin. While following the instructions and copy/pasting the code from the readme, it generates a build error: 

> e: file:///[path-to-file]/RNAppFragment.kt:8:49 Expecting a top level declaration

### Test plan

Trying to compile content with this line in it will fail:

```kt
import com.callstack.rnbrownfield.RNViewFactory # exposed by RN app framework
```

Trying to compile content with this line will succeed:

```kt
import com.callstack.rnbrownfield.RNViewFactory // exposed by RN app framework
```
