### PR TITLE
feat: add method to deallocate reactNativeFactory instance for iOS

### DIFF
--- a/docs/OBJECTIVE_C.md
+++ b/docs/OBJECTIVE_C.md
@@ -70,6 +70,16 @@ Examples:
 }, launchOptions];
 ```
 
+`stopReactNative`
+
+Stops React Native and releases the underlying runtime. Safe to call multiple times. Call it after all React Native views are dismissed.
+
+Examples:
+
+```objc
+[[ReactNativeBrownfield shared] stopReactNative];
+```
+
 `view`
 
 Creates a React Native view for the specified module name.

--- a/docs/SWIFT.md
+++ b/docs/SWIFT.md
@@ -70,6 +70,16 @@ ReactNativeBrownfield.shared.startReactNative(onBundleLoaded: {
 }, launchOptions: launchOptions)
 ```
 
+`stopReactNative`
+
+Stops React Native and releases the underlying runtime. Safe to call multiple times. Call it after all React Native views are dismissed.
+
+Examples:
+
+```swift
+ReactNativeBrownfield.shared.stopReactNative()
+```
+
 `view`
 
 Creates a React Native view for the specified module name.

--- a/example/swift/App.swift
+++ b/example/swift/App.swift
@@ -19,25 +19,25 @@ struct MyApp: App {
 struct ContentView: View {
   var body: some View {
         NavigationView {
-        VStack {
-            Text("React Native Brownfield App")
-            .font(.title)
-            .bold()
-            .padding()
-            .multilineTextAlignment(.center)
-            
-            NavigationLink("Push React Native Screen") {
-            ReactNativeView(moduleName: "ReactNative")
-                .navigationBarHidden(true)
-            }
-            
-            Button("Stop React Native") {
-            ReactNativeBrownfield.shared.stopReactNative()
-            }
-            .buttonStyle(PlainButtonStyle())
-            .padding(.top)
-            .foregroundColor(.red)
-        }
+          VStack {
+              Text("React Native Brownfield App")
+              .font(.title)
+              .bold()
+              .padding()
+              .multilineTextAlignment(.center)
+              
+              NavigationLink("Push React Native Screen") {
+              ReactNativeView(moduleName: "ReactNative")
+                  .navigationBarHidden(true)
+              }
+              
+              Button("Stop React Native") {
+              ReactNativeBrownfield.shared.stopReactNative()
+              }
+              .buttonStyle(PlainButtonStyle())
+              .padding(.top)
+              .foregroundColor(.red)
+          }
         }
     }
 }

--- a/example/swift/App.swift
+++ b/example/swift/App.swift
@@ -17,19 +17,27 @@ struct MyApp: App {
 }
 
 struct ContentView: View {
-    var body: some View {
+  var body: some View {
         NavigationView {
-            VStack {
-                Text("React Native Brownfield App")
-                    .font(.title)
-                    .bold()
-                    .padding()
-
-                NavigationLink("Push React Native Screen") {
-                    ReactNativeView(moduleName: "ReactNative")
-                        .navigationBarHidden(true)
-                }
+        VStack {
+            Text("React Native Brownfield App")
+            .font(.title)
+            .bold()
+            .padding()
+            .multilineTextAlignment(.center)
+            
+            NavigationLink("Push React Native Screen") {
+            ReactNativeView(moduleName: "ReactNative")
+                .navigationBarHidden(true)
             }
-        }.navigationViewStyle(StackNavigationViewStyle())
+            
+            Button("Stop React Native") {
+            ReactNativeBrownfield.shared.stopReactNative()
+            }
+            .buttonStyle(PlainButtonStyle())
+            .padding(.top)
+            .foregroundColor(.red)
+        }
+        }
     }
 }

--- a/example/swift/Podfile.lock
+++ b/example/swift/Podfile.lock
@@ -2322,7 +2322,7 @@ PODS:
     - SocketRocket
   - ReactAppDependencyProvider (0.82.1):
     - ReactCodegen
-  - ReactBrownfield (1.2.0):
+  - ReactBrownfield (2.0.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -2811,12 +2811,12 @@ SPEC CHECKSUMS:
   React-utils: abf37b162f560cd0e3e5d037af30bb796512246d
   React-webperformancenativemodule: 50a57c713a90d27ae3ab947a6c9c8859bcb49709
   ReactAppDependencyProvider: a45ef34bb22dc1c9b2ac1f74167d9a28af961176
-  ReactBrownfield: ba90b7c2be36c3ef4ad47e777610ca7c2b0fdf06
+  ReactBrownfield: 10f9f7370cd8bd6ef30eb9c736d774f9d17565f7
   ReactCodegen: 878add6c7d8ff8cea87697c44d29c03b79b6f2d9
   ReactCommon: 804dc80944fa90b86800b43c871742ec005ca424
   RNScreens: d821082c6dd1cb397cc0c98b026eeafaa68be479
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: 8e01cef9947ca77f0477a098f0b32848a8e448c6
+  Yoga: 689c8e04277f3ad631e60fe2a08e41d411daf8eb
 
 PODFILE CHECKSUM: c4add71d30d7b14523f41a732fbf4937f4edbe0f
 

--- a/ios/ReactNativeBrownfield.swift
+++ b/ios/ReactNativeBrownfield.swift
@@ -31,6 +31,7 @@ class ReactNativeBrownfieldDelegate: RCTDefaultReactNativeFactoryDelegate {
   public static let shared = ReactNativeBrownfield()
   private var onBundleLoaded: (() -> Void)?
   private var delegate = ReactNativeBrownfieldDelegate()
+  private var storedLaunchOptions: [AnyHashable: Any]?
   
   /**
    * Path to JavaScript root.
@@ -94,11 +95,12 @@ class ReactNativeBrownfieldDelegate: RCTDefaultReactNativeFactoryDelegate {
     let resolvedFactory = factory
 
     let rootViewFactory = resolvedFactory.rootViewFactory
+    let resolvedLaunchOptions = launchOptions ?? storedLaunchOptions
 
     return rootViewFactory.view(
       withModuleName: moduleName,
       initialProperties: initialProps,
-      launchOptions: launchOptions
+      launchOptions: resolvedLaunchOptions
     )
   }
   
@@ -118,8 +120,8 @@ class ReactNativeBrownfieldDelegate: RCTDefaultReactNativeFactoryDelegate {
    * @param launchOptions Launch options, typically passed from AppDelegate.
    */
   @objc public func startReactNative(onBundleLoaded: (() -> Void)?, launchOptions: [AnyHashable: Any]?) {
+    storedLaunchOptions = launchOptions
     guard reactNativeFactory == nil else { return }
-    _ = launchOptions
     _ = factory
     
     if let onBundleLoaded {
@@ -158,6 +160,7 @@ class ReactNativeBrownfieldDelegate: RCTDefaultReactNativeFactoryDelegate {
     NotificationCenter.default.removeObserver(self)
     onBundleLoaded = nil
 
+    storedLaunchOptions = nil
     reactNativeFactory = nil
   }
   


### PR DESCRIPTION
### Summary

* Adds public iOS API stopReactNative() to deallocate the React Native runtime created by RCTReactNativeFactory and allow clean re‑initialization later. Fixes [#134](https://github.com/callstack/react-native-brownfield/issues/134).
* Old Architecture: calls [bridge.invalidate()](https://reactnative.dev/docs/legacy/native-modules-ios#invalidate) to tear down JS and native modules.
* New Architecture: releases the runtime by dropping strong references (no public stop API on `RCTHost`).
* Prevents crashes when pushing a React Native screen after stopping.
* Removes stale lazy caching of `rootViewFactory` to avoid retaining the old runtime.
* Documentation updates for the new API and usage:
   * docs/SWIFT.md
   * docs/OBJECTIVE_C.md
* Backwards compatible: existing `startReactNative()` API remains; `view()` now self‑heals if RN was previously stopped.

### Test plan

* Press the “Stop React Native” (to check app won't crash if `stopReactNative` called before RN was initialize)
* Push RN screen → pop → tap the “Stop React Native” button → push again (no crash).
* Repeat with both architectures toggled.
* Watch the Xcode Instruments graph to confirm RN objects are released after stop (RSS may not drop immediately).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an iOS `stopReactNative()` API to tear down the RN runtime, simplifies factory creation/usage, and updates docs and the Swift example.
> 
> - **iOS SDK (`ios/ReactNativeBrownfield.swift`)**:
>   - **New API**: `stopReactNative()` invalidates the bridge, removes observers, and clears the factory; safe to call multiple times.
>   - **Factory lifecycle**: Replaces cached `rootViewFactory` with a lazy `factory` creator; `view(...)` now resolves via `factory`; `startReactNative(..., launchOptions:)` simplified.
> - **Docs**:
>   - Add `stopReactNative` reference, description, and examples in `docs/SWIFT.md` and `docs/OBJECTIVE_C.md`.
> - **Example app** (`example/swift/App.swift`):
>   - Add "Stop React Native" button calling `ReactNativeBrownfield.shared.stopReactNative()`; minor UI tweaks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aab133981ccb4ab8b8d7e16ef8f55c68ae766049. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->