### PR TITLE
fix: use lazy rootViewFactory property in view method

### DIFF
--- a/ios/ReactNativeBrownfield.swift
+++ b/ios/ReactNativeBrownfield.swift
@@ -88,7 +88,7 @@ class ReactNativeBrownfieldDelegate: RCTDefaultReactNativeFactoryDelegate {
     initialProps: [AnyHashable: Any]?,
     launchOptions: [AnyHashable: Any]? = nil
   ) -> UIView? {
-    reactNativeFactory?.rootViewFactory.view(
+    rootViewFactory?.view(
       withModuleName: moduleName,
       initialProperties: initialProps,
       launchOptions: launchOptions


### PR DESCRIPTION
### Summary

The view method was calling reactNativeFactory?.rootViewFactory.view(...) instead of using the already defined lazy property rootViewFactory, making the lazy property redundant.

Modified view method in ReactNativeBrownfield.swift to use rootViewFactory?.view(...) instead of reactNativeFactory?.rootViewFactory.view(...)

### Test plan

Code builds successfully
Existing tests should continue to pass as the behavior is unchanged
No breaking changes introduced - the method signature and functionality remain identical


