### PR TITLE
fix: make android library evaluation depends on expo

### DIFF
--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/artifacts/ArtifactsResolver.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/artifacts/ArtifactsResolver.kt
@@ -20,6 +20,7 @@ import com.callstack.react.brownfield.processors.VariantTaskProvider
 import com.callstack.react.brownfield.shared.BaseProject
 import com.callstack.react.brownfield.shared.GradleProps
 import com.callstack.react.brownfield.utils.Extension
+import com.callstack.react.brownfield.utils.Utils
 import org.gradle.api.ProjectConfigurationException
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ResolvedArtifact
@@ -55,7 +56,7 @@ class ArtifactsResolver(
          * expo project does not exist in example-android-library so doing an
          * early exit.
          */
-        if (baseProject.project.name == "example-android-library") {
+        if (Utils.isExampleLibrary(baseProject.project.name)) {
             return
         }
 

--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/plugin/RNBrownfieldPlugin.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/plugin/RNBrownfieldPlugin.kt
@@ -7,7 +7,6 @@ import com.callstack.react.brownfield.shared.Constants.PROJECT_ID
 import com.callstack.react.brownfield.shared.Logging
 import com.callstack.react.brownfield.utils.DirectoryManager
 import com.callstack.react.brownfield.utils.Extension
-import com.callstack.react.brownfield.utils.Utils
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.ProjectConfigurationException
@@ -29,17 +28,17 @@ class RNBrownfieldPlugin
 
         override fun apply(project: Project) {
             verifyAndroidPluginApplied(project)
-
             initializers(project)
+
             /**
              * Make sure that expo project is evaluated before the android library.
              * This ensures that the expo modules are available to link with the
              * android library, when it is evaluated.
-             *
-             * this.extension.isExpo &&
              */
-            if (!Utils.isExampleLibrary(project.project.name)) {
-                project.evaluationDependsOn(":expo")
+            val expoProjectPath = ":expo"
+            val hasExpoProject = project.findProject(expoProjectPath) != null
+            if (hasExpoProject) {
+                project.evaluationDependsOn(expoProjectPath)
             }
 
             RNSourceSets.configure(project, extension)

--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/plugin/RNBrownfieldPlugin.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/plugin/RNBrownfieldPlugin.kt
@@ -7,6 +7,7 @@ import com.callstack.react.brownfield.shared.Constants.PROJECT_ID
 import com.callstack.react.brownfield.shared.Logging
 import com.callstack.react.brownfield.utils.DirectoryManager
 import com.callstack.react.brownfield.utils.Extension
+import com.callstack.react.brownfield.utils.Utils
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.ProjectConfigurationException
@@ -30,6 +31,17 @@ class RNBrownfieldPlugin
             verifyAndroidPluginApplied(project)
 
             initializers(project)
+            /**
+             * Make sure that expo project is evaluated before the android library.
+             * This ensures that the expo modules are available to link with the
+             * android library, when it is evaluated.
+             *
+             * this.extension.isExpo &&
+             */
+            if (!Utils.isExampleLibrary(project.project.name)) {
+                project.evaluationDependsOn(":expo")
+            }
+
             RNSourceSets.configure(project, extension)
             projectConfigurations.setup()
             registerRClassTransformer()

--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/plugin/RNSourceSets.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/plugin/RNSourceSets.kt
@@ -3,6 +3,7 @@ package com.callstack.react.brownfield.plugin
 import com.android.build.gradle.LibraryExtension
 import com.callstack.react.brownfield.exceptions.NameSpaceNotFound
 import com.callstack.react.brownfield.utils.Extension
+import com.callstack.react.brownfield.utils.Utils
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.file.Directory
@@ -27,7 +28,7 @@ object RNSourceSets {
          * be present on the consuming library, which is not the case
          * with our example library.
          */
-        if (project.name == "example-android-library") {
+        if (Utils.isExampleLibrary(project.name)) {
             return
         }
         this.project = project

--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/utils/Utils.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/utils/Utils.kt
@@ -36,4 +36,8 @@ object Utils {
             output.appendText("\n${file.readText(Charsets.UTF_8)}\n")
         }
     }
+
+    fun isExampleLibrary(projectName: String): Boolean {
+        return projectName == "example-android-library"
+    }
 }


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

This PR fixes an edge case where in an expo project, if the consumer android library has the name starting before `expo` then it gets evaluated after `expo`, hence the expo libraries are not linked with the android library. To fix that behavior, we add a dependency on `expo` evaluation and then the consumer android library gets evaluated. This ensures that the expo libraries will be present and linked correctly with the android library when it is evaluated.

Issue fixed: https://github.com/callstack/react-native-brownfield/issues/135


### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

- In an expo project, create a brownfield library where name starts from `a | b | c | d | e` for eg, `:brownlibrary | :expobrownfieldlibrary`
- Generate the AAR, consume it and make sure the host android app does not crash

<br/>

- Follow the similar steps but with library name starting after the letter `e`, for eg: `:mylibrary`

<br />

- Verify the non-expo project, having the android library works fine after these changes

<hr />



 

https://github.com/user-attachments/assets/edc25f8a-7c71-440b-a8f1-28e3340c420c


