### PR TITLE
fix: explicitly specify jsBundleAssetPath to fix loading of JS bundle in release mode on RN 0.81 & 0.82

### DIFF
--- a/android/src/main/java/com/callstack/reactnativebrownfield/ReactNativeBrownfield.kt
+++ b/android/src/main/java/com/callstack/reactnativebrownfield/ReactNativeBrownfield.kt
@@ -77,6 +77,7 @@ class ReactNativeBrownfield private constructor(val reactHost: ReactHost) {
                     packageList = (options["packages"] as? List<*> ?: emptyList<ReactPackage>())
                         .filterIsInstance<ReactPackage>(),
                     jsMainModulePath = options["mainModuleName"] as? String ?: "index",
+                    jsBundleAssetPath = options["bundleAssetPath"] as? String ?: "index.android.bundle",
                     useDevSupport = options["useDeveloperSupport"] as? Boolean
                         ?: ReactBuildConfig.DEBUG,
                     jsRuntimeFactory = null

--- a/docs/JAVA.md
+++ b/docs/JAVA.md
@@ -75,7 +75,8 @@ Params:
 Available options:
 - `useDeveloperSupport`: `Boolean` - Flag to use dev support.
 - `packages`: `List<ReactPackage>` - List of your React Native Native modules.
-- `mainModuleName`: `String` - Path to react native entry file.
+- `mainModuleName`: `String` - Path to react native entry file (when loading from Metro).
+- `jsBundleAssetPath`: `String` - Path to react native bundle asset file (when loading from app assets), appended to `asset://`.
 
 Examples:
 

--- a/docs/KOTLIN.md
+++ b/docs/KOTLIN.md
@@ -58,7 +58,8 @@ Params:
 Available options:
 - `useDeveloperSupport`: `Boolean` - Flag to use dev support.
 - `packages`: `List<ReactPackage>` - List of your React Native Native modules.
-- `mainModuleName`: `String` - Path to react native entry file.
+- `mainModuleName`: `String` - Path to react native entry file (when loading from Metro).
+- `jsBundleAssetPath`: `String` - Path to react native bundle asset file (when loading from app assets), appended to `asset://`.
 
 Examples:
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

RN 0.81 & 0.82 have a bugged default value of the `jsBundleAssetPath` argument, which controls the filename to be loaded from `asset://`. By default, it is `index`, which is correct for Metro (dev mode) `jsMainModulePath`, but incorrect for asset bundle - it should be `index.android.bundle`.

The fix is present in RN upstream and included in 0.83 RC (https://github.com/facebook/react-native/pull/53546), but has not been backported.

This PR passes the correct default value explicitly and also allows users to pass a custom value for this argument via the options HashMap.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
Run an app in release variant using an exported AAR & verify that the JS bundle is loaded and executed correctly.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Explicitly sets `jsBundleAssetPath` (default `index.android.bundle`) in React host initialization and documents the option in Java/Kotlin guides.
> 
> - **Android**:
>   - Update `ReactNativeBrownfield.initialize(application, options, ...)` to pass `jsBundleAssetPath` to `getDefaultReactHost`, defaulting to `"index.android.bundle"` and allowing override via `options["bundleAssetPath"]`.
> - **Docs**:
>   - Clarify `mainModuleName` applies when loading from Metro.
>   - Add `jsBundleAssetPath` option description for Java/Kotlin (`docs/JAVA.md`, `docs/KOTLIN.md`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff9b0471bb3a7ab6c7a92ec3ff9017ba6e9c630c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->