### PR TITLE
chore: bump version to `0.6.0`

### DIFF
--- a/gradle-plugins/react/README.md
+++ b/gradle-plugins/react/README.md
@@ -21,7 +21,7 @@ buildscript {
         classpath("com.android.tools.build:gradle")
         classpath("com.facebook.react:react-native-gradle-plugin")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin")
-+       classpath("com.callstack.react:brownfield-gradle-plugin:0.4.0")
++       classpath("com.callstack.react:brownfield-gradle-plugin:0.6.0")
     }
 }
 ```
@@ -60,7 +60,7 @@ buildscript {
         classpath("com.android.tools.build:gradle")
         classpath("com.facebook.react:react-native-gradle-plugin")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin")
-+       classpath("com.callstack.react:brownfield:0.3.0")
++       classpath("com.callstack.react:brownfield-gradle-plugin:0.6.0")
     }
 }
 ```

--- a/gradle-plugins/react/brownfield/gradle.properties
+++ b/gradle-plugins/react/brownfield/gradle.properties
@@ -1,6 +1,6 @@
 PROJECT_ID=com.callstack.react.brownfield
 ARTIFACT_ID=brownfield-gradle-plugin
-VERSION=0.5.0
+VERSION=0.6.0
 GROUP=com.callstack.react
 IMPLEMENTATION_CLASS=com.callstack.react.brownfield.plugin.RNBrownfieldPlugin
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps brownfield Gradle plugin to 0.6.0 and updates README install instructions (classpath, plugin id, mavenLocal, artifact coords).
> 
> - **Version bump**
>   - Update `VERSION` in `gradle-plugins/react/brownfield/gradle.properties` from `0.5.0` to `0.6.0`.
> - **Docs (installation)**
>   - Update README install snippets:
>     - Bump classpath to `com.callstack.react:brownfield-gradle-plugin:0.6.0`.
>     - Add `id("com.callstack.react.brownfield")` to `plugins` block examples.
>     - Add `mavenLocal()` to local setup instructions.
>     - Fix artifact coordinates in local example to `brownfield-gradle-plugin`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5465d803e7567a2a4bff1f7eaef21e2d87ec5a2d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->