### PR TITLE
fix: duplicate dynamic libs by retaining the instance of the map

### DIFF
--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/processors/JNILibsProcessor.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/processors/JNILibsProcessor.kt
@@ -44,9 +44,14 @@ class JNILibsProcessor : BaseProject() {
             it.dependsOn(copyTask)
 
             it.doFirst {
+                val existingJNILibs =
+                    listOf("arm64-v8a", "armeabi-v7a", "x86_64", "x86")
+                        .associateWith { mutableListOf<String>() }
+                        .toMutableMap()
+
                 for (archiveLibrary in aarLibraries) {
                     val jniDir = archiveLibrary.getJniDir()
-                    processNestedLibs(jniDir.listFiles())
+                    processNestedLibs(jniDir.listFiles(), existingJNILibs)
                     if (jniDir.exists()) {
                         val filteredSourceSets = androidExtension.sourceSets.filter { sourceSet -> sourceSet.name == variant.name }
                         filteredSourceSets.forEach { sourceSet -> sourceSet.jniLibs.srcDir(jniDir) }
@@ -86,12 +91,10 @@ class JNILibsProcessor : BaseProject() {
         }
     }
 
-    private fun processNestedLibs(files: Array<File>?) {
-        val existingJNILibs =
-            listOf("arm64-v8a", "armeabi-v7a", "x86_64", "x86")
-                .associateWith { mutableListOf<String>() }
-                .toMutableMap()
-
+    private fun processNestedLibs(
+        files: Array<File>?,
+        existingJNILibs: MutableMap<String, MutableList<String>>,
+    ) {
         files?.forEach { folder ->
             val libFiles = folder.listFiles() ?: return@forEach
             val libList = existingJNILibs[folder.name] ?: return@forEach


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

This fixes the bug reported by installing the latest reanimated which requires you to also install the worklets package. Since reanimated internally adds worklets as a subproject, it brings in the worklets dynamic (.so) lib with itself. Now, when worklets is compiled separately, we face the duplicate dynamic lib error because worklets.so already exists in the aar.

This was happening because we internally maintain a map to evaluate if a certain dynamic lib is already added to the AAR. However, due to the implementation details that map was being re-instantiated in the loop. The fix is to retain that map to correctly evaluate whether a dynamic lib is added to the AAR or not.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

Tested locally
