### PR TITLE
refactor: rename `upperCaseVariantName` to more descriptive `capitalizedVariantName`

### DIFF
--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/processors/JNILibsProcessor.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/processors/JNILibsProcessor.kt
@@ -28,8 +28,8 @@ class JNILibsProcessor : BaseProject() {
         explodeTasks: MutableList<Task>,
         variant: LibraryVariant,
     ) {
-        val upperCaseVariantName = variant.name.replaceFirstChar(Char::titlecase)
-        val taskName = "merge${upperCaseVariantName}JniLibFolders"
+        val capitalizedVariantName = variant.name.replaceFirstChar(Char::titlecase)
+        val taskName = "merge${capitalizedVariantName}JniLibFolders"
         val mergeJniLibsTask = project.tasks.named(taskName)
 
         if (!mergeJniLibsTask.isPresent) {

--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/processors/ProguardProcessor.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/processors/ProguardProcessor.kt
@@ -22,13 +22,13 @@ import org.gradle.api.tasks.TaskProvider
 import java.io.File
 
 class ProguardProcessor(variant: LibraryVariant) : BaseProject() {
-    private val upperCaseVariantName = variant.name.replaceFirstChar(Char::titlecase)
+    private val capitalizedVariantName = variant.name.replaceFirstChar(Char::titlecase)
 
     fun processConsumerFiles(
         aarLibs: Collection<AndroidArchiveLibrary>,
         explodeTasks: MutableList<Task>,
     ) {
-        val mergeTaskName = "merge${upperCaseVariantName}ConsumerProguardFiles"
+        val mergeTaskName = "merge${capitalizedVariantName}ConsumerProguardFiles"
         val mergeFileTask = project.tasks.named(mergeTaskName)
 
         if (!mergeFileTask.isPresent) {
@@ -50,7 +50,7 @@ class ProguardProcessor(variant: LibraryVariant) : BaseProject() {
         explodeTasks: MutableList<Task>,
     ) {
         val mergeGenerateProguardTask: TaskProvider<*>?
-        val mergeName = "merge${upperCaseVariantName}GeneratedProguardFiles"
+        val mergeName = "merge${capitalizedVariantName}GeneratedProguardFiles"
         mergeGenerateProguardTask = project.tasks.named(mergeName)
 
         mergeGenerateProguardTask?.configure { task ->

--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/processors/VariantHelper.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/processors/VariantHelper.kt
@@ -28,7 +28,7 @@ import java.nio.file.Path
 import java.nio.file.Paths
 
 class VariantHelper(private val variant: LibraryVariant) : BaseProject() {
-    private val upperCaseVariantName = variant.name.replaceFirstChar(Char::titlecase)
+    private val capitalizedVariantName = variant.name.replaceFirstChar(Char::titlecase)
 
     fun getVariant(): LibraryVariant {
         return variant
@@ -117,7 +117,7 @@ class VariantHelper(private val variant: LibraryVariant) : BaseProject() {
         aarLibraries: Collection<AndroidArchiveLibrary>,
         explodeTasks: MutableList<Task>,
     ) {
-        val taskPath = "generate${upperCaseVariantName}Resources"
+        val taskPath = "generate${capitalizedVariantName}Resources"
         val resourceGenTask = project.tasks.named(taskPath)
 
         if (!resourceGenTask.isPresent) {

--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/processors/VariantProcessor.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/processors/VariantProcessor.kt
@@ -26,7 +26,7 @@ import org.gradle.api.tasks.TaskProvider
 import java.io.File
 
 class VariantProcessor(private val variant: LibraryVariant) : BaseProject() {
-    private val upperCaseVariantName = variant.name.replaceFirstChar(Char::titlecase)
+    private val capitalizedVariantName = variant.name.replaceFirstChar(Char::titlecase)
     private val variantHelper = VariantHelper(variant)
     private val variantTaskProvider = VariantTaskProvider(variantHelper)
     private val jniLibsProcessor = JNILibsProcessor()
@@ -48,14 +48,14 @@ class VariantProcessor(private val variant: LibraryVariant) : BaseProject() {
 
     fun processVariant(artifacts: Collection<ResolvedArtifact>) {
         setup()
-        val preBuildTaskPath = "pre${upperCaseVariantName}Build"
+        val preBuildTaskPath = "pre${capitalizedVariantName}Build"
         val prepareTask = project.tasks.named(preBuildTaskPath)
 
         if (!prepareTask.isPresent) {
             throw TaskNotFound("Can not find $preBuildTaskPath task")
         }
 
-        if (upperCaseVariantName == "Release") {
+        if (capitalizedVariantName == "Release") {
             prepareTask.dependsOn(":app:createBundleReleaseJsAndAssets")
         }
 
@@ -77,7 +77,7 @@ class VariantProcessor(private val variant: LibraryVariant) : BaseProject() {
 
     private fun mergeClassesAndJars(bundleTask: TaskProvider<Task>) {
         val syncLibTask = project.tasks.named(variantHelper.getSyncLibJarsTaskPath())
-        val extractAnnotationsTask = project.tasks.named("extract${upperCaseVariantName}Annotations")
+        val extractAnnotationsTask = project.tasks.named("extract${capitalizedVariantName}Annotations")
 
         mergeClassTask = variantTaskProvider.classesMergeTask(aarLibraries, jarFiles, explodeTasks)
         syncLibTask.configure {
@@ -88,7 +88,7 @@ class VariantProcessor(private val variant: LibraryVariant) : BaseProject() {
             it.inputs.files(jarFiles).withPathSensitivity(PathSensitivity.RELATIVE)
         }
 
-        project.tasks.named("transform${upperCaseVariantName}ClassesWithAsm").configure {
+        project.tasks.named("transform${capitalizedVariantName}ClassesWithAsm").configure {
             it.dependsOn(mergeClassTask)
         }
         extractAnnotationsTask.configure {
@@ -97,7 +97,7 @@ class VariantProcessor(private val variant: LibraryVariant) : BaseProject() {
 
         if (!variant.buildType.isMinifyEnabled) {
             val mergeJars = variantTaskProvider.jarMergeTask(syncLibTask, aarLibraries, jarFiles, explodeTasks)
-            project.tasks.named("bundle${upperCaseVariantName}LocalLintAar").configure {
+            project.tasks.named("bundle${capitalizedVariantName}LocalLintAar").configure {
                 it.dependsOn(mergeJars)
             }
             bundleTask.configure {
@@ -155,7 +155,7 @@ class VariantProcessor(private val variant: LibraryVariant) : BaseProject() {
     ): Copy {
         val group = artifact.moduleVersion.id.group.replaceFirstChar(Char::titlecase)
         val name = artifact.name.replaceFirstChar(Char::titlecase)
-        val taskName = "explode$group$name$upperCaseVariantName"
+        val taskName = "explode$group$name$capitalizedVariantName"
         val explodeTask =
             project.tasks.create(taskName, Copy::class.java) {
                 it.from(project.zipTree(artifact.file.absolutePath))

--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/processors/VariantTaskProvider.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/processors/VariantTaskProvider.kt
@@ -15,15 +15,15 @@ import java.io.File
 
 class VariantTaskProvider(private val variantHelper: VariantHelper) : BaseProject() {
     private val variant = variantHelper.getVariant()
-    private val upperCaseVariantName = variant.name.replaceFirstChar(Char::titlecase)
+    private val capitalizedVariantName = variant.name.replaceFirstChar(Char::titlecase)
 
     fun classesMergeTask(
         aarLibraries: Collection<AndroidArchiveLibrary>,
         jarFiles: MutableList<File>,
         explodeTasks: MutableList<Task>,
     ): TaskProvider<Task> {
-        val mergeClassesTaskName = "mergeClasses$upperCaseVariantName"
-        val kotlinCompileTaskName = "compile${upperCaseVariantName}Kotlin"
+        val mergeClassesTaskName = "mergeClasses$capitalizedVariantName"
+        val kotlinCompileTaskName = "compile${capitalizedVariantName}Kotlin"
 
         return project.tasks.register(mergeClassesTaskName) {
             it.outputs.upToDateWhen { false }
@@ -54,7 +54,7 @@ class VariantTaskProvider(private val variantHelper: VariantHelper) : BaseProjec
         jarFiles: MutableList<File>,
         explodeTasks: MutableList<Task>,
     ): TaskProvider<Task> {
-        return project.tasks.register("mergeJars$upperCaseVariantName") {
+        return project.tasks.register("mergeJars$capitalizedVariantName") {
             it.dependsOn(explodeTasks)
             it.dependsOn(variantHelper.getJavaCompileTask())
             it.mustRunAfter(syncLibTask)
@@ -92,14 +92,14 @@ class VariantTaskProvider(private val variantHelper: VariantHelper) : BaseProjec
         val processManifestTask = variantHelper.getProcessManifest()
         val manifestOutput =
             project.file(
-                "$buildDir/intermediates/merged_manifest/${variant.name}/process${upperCaseVariantName}Manifest/AndroidManifest.xml",
+                "$buildDir/intermediates/merged_manifest/${variant.name}/process${capitalizedVariantName}Manifest/AndroidManifest.xml",
             )
 
         val inputManifests = aarLibraries.map { it.getManifestFile() }
 
         val manifestsMergeTask =
             project.tasks.register(
-                "merge${upperCaseVariantName}Manifest",
+                "merge${capitalizedVariantName}Manifest",
                 ManifestMerger::class.java,
             ) {
                 it.setGradleVersion(project.gradle.gradleVersion)
@@ -148,7 +148,7 @@ class VariantTaskProvider(private val variantHelper: VariantHelper) : BaseProjec
     }
 
     fun processDeepLinkTasks(explodeTasks: MutableList<Task>) {
-        val taskName = "extractDeepLinksForAar$upperCaseVariantName"
+        val taskName = "extractDeepLinksForAar$capitalizedVariantName"
         val extractDeepLinks = project.tasks.named(taskName)
 
         if (!extractDeepLinks.isPresent) {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

This PR addresses the refactor idea brought up in #163. There are multiple places in code similar to `val upperCaseVariantName = variant.name.replaceFirstChar(Char::titlecase)`, which are misleading: the transform alters the first char to be uppercase, rest remains the same; the name is therefore misleading since it claims the whole variable would be uppercase. A name I'd suggest is `capitalizedVariantName`, since it reflects the naming best in my opinion.

Fixes - https://github.com/callstack/react-native-brownfield/issues/164

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
CI green.