### PR TITLE
feat: use stripped native so libs

### DIFF
--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/utils/Extension.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/utils/Extension.kt
@@ -45,4 +45,11 @@ open class Extension {
      * bundled.
      */
     var dynamicLibs = listOf<String>()
+
+    /**
+     * Whether to use stripped .so files.
+     *
+     * Default value is `false`
+     */
+    var experimentalUseStrippedSoFiles = false
 }


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

I've noticed that plugin packages third party libraries `.so` files that weren't stripped. This PR fixes that.

In result, using stripped `.so` files causes AAR size to be reduced by over 50%

### Test plan

Everything works as before, same native libs are packaged into `jni` directory of `.aar`
