### PR TITLE
feat(brownie): add iOS selector support to @UseStore

### DIFF
--- a/apps/TesterIntegrated/swift/App.swift
+++ b/apps/TesterIntegrated/swift/App.swift
@@ -12,7 +12,7 @@ let initialState = BrownfieldStore(
  Toggles testing playground for side by side brownie mode.
  Default: false
  */
-let isSideBySideMode = true
+let isSideBySideMode = false
 
 @main
 struct MyApp: App {
@@ -87,9 +87,8 @@ struct MyApp: App {
     var body: some View {
       VStack {
         Text("Count: \(Int(counter))")
-        Button("Increment") {
-          $counter.set { $0 + 1 }
-        }
+        Stepper(value: $counter, label: { Text("Increment") })
+        
         .buttonStyle(.borderedProminent)
         .padding(.bottom)
       }
@@ -97,15 +96,12 @@ struct MyApp: App {
   }
 
   struct UserView: View {
-    @UseStore(\BrownfieldStore.user) var user
+    @UseStore(\BrownfieldStore.user.name) var name
 
     var body: some View {
-      TextField("Name", text: Binding(
-        get: { user.name },
-        set: { $user.set(User(name: $0)) }
-      ))
-      .textFieldStyle(.roundedBorder)
-      .padding(.horizontal)
+      TextField("Name", text: $name)
+        .textFieldStyle(.roundedBorder)
+        .padding(.horizontal)
     }
   }
 
@@ -122,10 +118,7 @@ struct MyApp: App {
         Text("User: \(user.name)")
         Text("Count: \(Int(counter))")
 
-        TextField("Name", text: Binding(
-          get: { user.name },
-          set: { $user.set(User(name: $0)) }
-        ))
+        TextField("Name", text: $user.name)
         .textFieldStyle(.roundedBorder)
         .padding(.horizontal)
 

--- a/apps/TesterIntegrated/swift/Generated/BrownfieldStore.swift
+++ b/apps/TesterIntegrated/swift/Generated/BrownfieldStore.swift
@@ -5,6 +5,12 @@ import Brownie
 //
 //   let brownfieldStore = try? JSONDecoder().decode(BrownfieldStore.self, from: jsonData)
 
+//
+// Hashable or Equatable:
+// The compiler will not be able to synthesize the implementation of Hashable or Equatable
+// for types that require the use of JSONAny, nor will the implementation of Hashable be
+// synthesized for types that have collections (such as arrays or dictionaries).
+
 import Foundation
 
 // MARK: - BrownfieldStore
@@ -12,6 +18,12 @@ struct BrownfieldStore: Codable, Equatable {
     var counter: Double
     var user: User
 }
+
+//
+// Hashable or Equatable:
+// The compiler will not be able to synthesize the implementation of Hashable or Equatable
+// for types that require the use of JSONAny, nor will the implementation of Hashable be
+// synthesized for types that have collections (such as arrays or dictionaries).
 
 // MARK: - User
 struct User: Codable, Equatable {

--- a/apps/TesterIntegrated/swift/Generated/SettingsStore.swift
+++ b/apps/TesterIntegrated/swift/Generated/SettingsStore.swift
@@ -5,15 +5,21 @@ import Brownie
 //
 //   let settingsStore = try? JSONDecoder().decode(SettingsStore.self, from: jsonData)
 
+//
+// Hashable or Equatable:
+// The compiler will not be able to synthesize the implementation of Hashable or Equatable
+// for types that require the use of JSONAny, nor will the implementation of Hashable be
+// synthesized for types that have collections (such as arrays or dictionaries).
+
 import Foundation
 
 // MARK: - SettingsStore
-struct SettingsStore: Codable {
+struct SettingsStore: Codable, Equatable {
     var notificationsEnabled, privacyMode: Bool
     var theme: Theme
 }
 
-enum Theme: String, Codable {
+enum Theme: String, Codable, Equatable {
     case dark = "dark"
     case light = "light"
 }

--- a/docs/docs/brownie/swift-usage.mdx
+++ b/docs/docs/brownie/swift-usage.mdx
@@ -82,22 +82,24 @@ Every `@UseStore` requires a KeyPath selector. This:
 ```
 
 :::info Equatable Requirement
-Selected values must conform to `Equatable` for change detection. Add `Equatable` to your generated types.
+Selected values must conform to `Equatable` for change detection.
 :::
 
 ### Updating State
 
-Use the projected value (`$`) to access setter methods:
+The projected value (`$`) returns a standard SwiftUI `Binding<Value>`:
 
 ```swift
-// Set value directly
-$counter.set(10)
+// Use with any SwiftUI control that accepts Binding
+Stepper(value: $counter) { Text("Count: \(Int(counter))") }
+Slider(value: $counter, in: 0...100)
+Toggle("Enabled", isOn: $isEnabled)
 
-// Set with closure (receives current value)
+// Set with closure (Brownie extension on Binding)
 $counter.set { $0 + 1 }
 
-// For nested types, replace the whole object
-$user.set(User(name: "John"))
+// Access nested properties via Binding subscript
+TextField("Name", text: $user.name)
 ```
 
 ### Multiple Selectors
@@ -124,18 +126,26 @@ struct MyView: View {
 
 ### TextField Binding
 
-For two-way binding with TextField, create a `Binding`:
+Use the binding directly or select a nested property:
 
 ```swift
+// Option 1: Select the nested property directly
+struct UserView: View {
+  @UseStore(\BrownfieldStore.user.name) var name
+
+  var body: some View {
+    TextField("Name", text: $name)
+      .textFieldStyle(.roundedBorder)
+  }
+}
+
+// Option 2: Select parent and access nested binding
 struct UserView: View {
   @UseStore(\BrownfieldStore.user) var user
 
   var body: some View {
-    TextField("Name", text: Binding(
-      get: { user.name },
-      set: { $user.set(User(name: $0)) }
-    ))
-    .textFieldStyle(.roundedBorder)
+    TextField("Name", text: $user.name)
+      .textFieldStyle(.roundedBorder)
   }
 }
 ```
@@ -245,19 +255,18 @@ Property wrapper for SwiftUI with required KeyPath selector:
 @UseStore(\BrownfieldStore.counter) var counter
 ```
 
-| Property         | Type           | Description                  |
-| ---------------- | -------------- | ---------------------------- |
-| `wrappedValue`   | `Value`        | Selected value (read-only)   |
-| `projectedValue` | `StoreBinding` | Setter access via `$counter` |
+| Property         | Type             | Description                         |
+| ---------------- | ---------------- | ----------------------------------- |
+| `wrappedValue`   | `Value`          | Selected value (read-only)          |
+| `projectedValue` | `Binding<Value>` | Standard SwiftUI binding via `$var` |
 
-### StoreBinding
+### Binding Extension
 
-Provides setter methods via projected value (`$counter`):
+Brownie adds a `set` method to `Binding` for closure-based updates:
 
-| Method    | Description                                    |
-| --------- | ---------------------------------------------- |
-| `set(_:)` | Set value directly                             |
-| `set(_:)` | Set value with closure receiving current value |
+```swift
+$counter.set { $0 + 1 }  // increment using current value
+```
 
 ### Store&lt;State&gt;
 

--- a/packages/brownie/ArchitectureOverview.md
+++ b/packages/brownie/ArchitectureOverview.md
@@ -303,19 +303,18 @@ packages/brownie/
 ```swift
 @UseStore(\BrownfieldStore.counter) var counter
 // counter -> Double (wrappedValue, read-only)
-// $counter.set(5) (projectedValue, direct value)
-// $counter.set { $0 + 1 } (projectedValue, closure receives current value)
+// $counter -> Binding<Double> (projectedValue, standard SwiftUI binding)
+// $counter.set { $0 + 1 } (Binding extension for closure updates)
 ```
 
 - Requires `WritableKeyPath` selector - forces explicit state selection
 - `Value` must conform to `Equatable` for change detection
 - Uses `removeDuplicates()` internally - only re-renders when selected value changes
 - `wrappedValue` - Selected value (read-only)
-- `projectedValue` - `StoreBinding` with `set` methods for updates
+- `projectedValue` - Standard `Binding<Value>` for SwiftUI controls
 
-**StoreBinding** - Setter wrapper returned via `$projectedValue`:
+**Binding Extension** - Adds closure-based setter:
 
-- `set(_:)` - Set value directly
 - `set(_:)` - Set value via closure that receives current value
 
 ## JS API

--- a/packages/brownie/ios/BrownieStore.swift
+++ b/packages/brownie/ios/BrownieStore.swift
@@ -20,26 +20,10 @@ public extension EnvironmentValues {
   }
 }
 
-/// Provides setter methods for the selected store value via projectedValue ($counter).
-public struct StoreBinding<State: BrownieStoreProtocol, Value> {
-  private let store: Store<State>
-  private let keyPath: WritableKeyPath<State, Value>
-
-  init(store: Store<State>, keyPath: WritableKeyPath<State, Value>) {
-    self.store = store
-    self.keyPath = keyPath
-  }
-
-  /// Set value directly
-  public func set(_ value: Value) {
-    store.set(keyPath, to: value)
-  }
-
+public extension Binding {
   /// Set value using closure that receives current value
-  public func set(_ updater: (Value) -> Value) {
-    let currentValue = store.get(keyPath)
-    let newValue = updater(currentValue)
-    store.set(keyPath, to: newValue)
+  func set(_ updater: (Value) -> Value) {
+    wrappedValue = updater(wrappedValue)
   }
 }
 
@@ -62,8 +46,11 @@ public struct UseStore<State: BrownieStoreProtocol, Value: Equatable>: DynamicPr
     observer.value
   }
 
-  public var projectedValue: StoreBinding<State, Value> {
-    StoreBinding(store: observer.store, keyPath: keyPath)
+  public var projectedValue: Binding<Value> {
+    Binding(
+      get: { observer.store.get(keyPath) },
+      set: { observer.store.set(keyPath, to: $0) }
+    )
   }
 }
 

--- a/packages/brownie/scripts/generators/swift.ts
+++ b/packages/brownie/scripts/generators/swift.ts
@@ -63,6 +63,8 @@ export async function generateSwift(
     rendererOptions: {
       'mutable-properties': 'true',
       initializers: 'false',
+      'swift-5-support': 'true',
+      protocol: 'equatable',
     },
   });
 


### PR DESCRIPTION
## Summary

- Add KeyPath-based selectors to `@UseStore` property wrapper
- Only re-renders when selected value changes (`removeDuplicates()`)
- New API: `@UseStore(\BrownfieldStore.counter) var counter`
- Setter via projected value: `$counter.set { $0 + 1 }`
- Add `StoreBinding` struct for scoped updates
- Update TesterIntegrated example app
- Update docs with new selector API