### PR TITLE
ci: optimize tester builds with turbo cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,20 +33,12 @@ jobs:
   tester-android:
     name: Integrated tester Android App
     runs-on: ubuntu-latest
-    needs: build-lint
+    env:
+      TURBO_CACHE_DIR: .turbo/android
 
     steps:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
-
-      - name: Validate Gradle Wrapper
-        uses: gradle/actions/wrapper-validation@6f229686ee4375cc4a86b2514c89bac4930e82c4 # v5
-
-      - name: Setup Java
-        uses: actions/setup-java@5d7b2146334bacf88728daaa70414a99f5164e0f # v5
-        with:
-          distribution: 'zulu'
-          java-version: '17'
 
       - name: Setup Node.js
         uses: actions/setup-node@65d868f8d4d85d7d4abb7de0875cde3fcc8798f5 # v6
@@ -60,7 +52,35 @@ jobs:
       - name: Build packages
         run: yarn build
 
+      - name: Cache turborepo for Android
+        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5
+        with:
+          path: ${{ env.TURBO_CACHE_DIR }}
+          key: ${{ runner.os }}-turborepo-android-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-turborepo-android-
+
+      - name: Check turborepo cache for Android
+        run: |
+          TURBO_CACHE_STATUS=$(node -p "($(yarn turbo run build:tester-integrated:android --cache-dir="${{ env.TURBO_CACHE_DIR }}" --dry=json)).tasks.find(t => t.task === 'build:tester-integrated:android').cache.status")
+
+          if [[ $TURBO_CACHE_STATUS == "HIT" ]]; then
+            echo "turbo_cache_hit=1" >> $GITHUB_ENV
+          fi
+
+      - name: Validate Gradle Wrapper
+        if: env.turbo_cache_hit != 1
+        uses: gradle/actions/wrapper-validation@6f229686ee4375cc4a86b2514c89bac4930e82c4 # v5
+
+      - name: Setup Java
+        if: env.turbo_cache_hit != 1
+        uses: actions/setup-java@5d7b2146334bacf88728daaa70414a99f5164e0f # v5
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+
       - name: Restore android build cache
+        if: env.turbo_cache_hit != 1
         uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5
         with:
           path: |
@@ -71,7 +91,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-tester-android-build-
 
-      - name: Resture Gradle cache
+      - name: Restore Gradle cache
+        if: env.turbo_cache_hit != 1
         uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5
         with:
           path: |
@@ -82,12 +103,16 @@ jobs:
             ${{ runner.os }}-tester-integrated-android-gradle-
 
       - name: Build integrated Android tester app
-        run: yarn run build:tester-integrated:android
+        env:
+          JAVA_OPTS: '-XX:MaxHeapSize=6g'
+        run: |
+          yarn turbo run build:tester-integrated:android --cache-dir="${{ env.TURBO_CACHE_DIR }}"
 
   tester-ios:
     name: Integrated tester iOS App
-    runs-on: macos-latest
-    needs: build-lint
+    runs-on: macos-15
+    env:
+      TURBO_CACHE_DIR: .turbo/ios
 
     steps:
       - name: Checkout
@@ -116,7 +141,24 @@ jobs:
       - name: Build packages
         run: yarn build
 
+      - name: Cache turborepo for iOS
+        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5
+        with:
+          path: ${{ env.TURBO_CACHE_DIR }}
+          key: ${{ runner.os }}-turborepo-ios-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-turborepo-ios-
+
+      - name: Check turborepo cache for iOS
+        run: |
+          TURBO_CACHE_STATUS=$(node -p "($(yarn turbo run build:tester-integrated:ios --cache-dir="${{ env.TURBO_CACHE_DIR }}" --dry=json)).tasks.find(t => t.task === 'build:tester-integrated:ios').cache.status")
+
+          if [[ $TURBO_CACHE_STATUS == "HIT" ]]; then
+            echo "turbo_cache_hit=1" >> $GITHUB_ENV
+          fi
+
       - name: Restore Pods cache
+        if: env.turbo_cache_hit != 1
         uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5
         with:
           path: |
@@ -126,10 +168,11 @@ jobs:
             ${{ runner.os }}-tester-ios-pods-
 
       - name: Install pods
+        if: env.turbo_cache_hit != 1
         run: |
           cd apps/TesterIntegrated/swift
           pod install
 
       - name: Build integrated iOS tester app
         run: |
-          yarn run build:tester-integrated:ios
+          yarn turbo run build:tester-integrated:ios --cache-dir="${{ env.TURBO_CACHE_DIR }}"


### PR DESCRIPTION
## Summary

- Remove `needs: build-lint` dependency - jobs now run in parallel
- Add turbo cache checking via dry-run before expensive steps
- Skip JDK, Gradle, pod install when turbo cache hits
- Use `macos-15` instead of `macos-latest` for faster iOS builds
- Use turbo directly with `--cache-dir` for persistent caching