### PR TITLE
refactor: rename brownie's __getStore global to __brownieGetStore to reduce 3p globals collision risk

### DIFF
--- a/packages/brownie/cpp/BrownieInstaller.cpp
+++ b/packages/brownie/cpp/BrownieInstaller.cpp
@@ -6,7 +6,7 @@ namespace brownie {
 
 void BrownieInstaller::install(facebook::jsi::Runtime &runtime) {
   auto getStore = facebook::jsi::Function::createFromHostFunction(
-      runtime, facebook::jsi::PropNameID::forAscii(runtime, "__getStore"), 1,
+      runtime, facebook::jsi::PropNameID::forAscii(runtime, "__brownieGetStore"), 1,
       [](facebook::jsi::Runtime &rt, const facebook::jsi::Value &,
          const facebook::jsi::Value *args, size_t count) -> facebook::jsi::Value {
         if (count < 1 || !args[0].isString()) {
@@ -25,7 +25,7 @@ void BrownieInstaller::install(facebook::jsi::Runtime &runtime) {
         return facebook::jsi::Object::createFromHostObject(rt, hostObject);
       });
 
-  runtime.global().setProperty(runtime, "__getStore", getStore);
+  runtime.global().setProperty(runtime, "__brownieGetStore", getStore);
 }
 
 } // namespace brownie

--- a/packages/brownie/src/index.ts
+++ b/packages/brownie/src/index.ts
@@ -23,7 +23,7 @@ const stores = new Map<string, StoreCache>();
 
 function getHostObject(key: string): HostObject {
   // @ts-expect-error - untyped global prop set by BrownieInstaller.cpp
-  return global.__getStore?.(key);
+  return global.__brownieGetStore?.(key);
 }
 
 function getOrCreateStore(key: string): StoreCache {


### PR DESCRIPTION
### Summary

This PR renames the global JS var `__getStore` to `__brownieGetStore` to reduce the risk of collision with e.g. a 3p lib that could want to define / write to this identifier.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->