### PR TITLE
refactor(brownie): hide kotlin codegen until ready for release

### DIFF
--- a/apps/RNApp/package.json
+++ b/apps/RNApp/package.json
@@ -49,9 +49,5 @@
   },
   "engines": {
     "node": ">=20"
-  },
-  "brownie": {
-    "kotlin": "./android/BrownfieldLib/src/main/java/com/rnapp/brownfieldlib/Generated",
-    "kotlinPackageName": "com.rnapp.brownfieldlib"
   }
 }

--- a/apps/TesterIntegrated/package.json
+++ b/apps/TesterIntegrated/package.json
@@ -35,10 +35,5 @@
   },
   "engines": {
     "node": ">=20"
-  },
-  "brownie": {
-    "swift": "./swift/Generated",
-    "kotlin": "./kotlin/app/src/main/java/com/callstack/kotlinexample/Generated",
-    "kotlinPackageName": "com.callstack.kotlinexample"
   }
 }

--- a/docs/docs/brownie/codegen.mdx
+++ b/docs/docs/brownie/codegen.mdx
@@ -5,34 +5,15 @@ The Brownfield CLI generates native types from your TypeScript store definitions
 ## Usage
 
 ```bash
-brownfield codegen                   # Generate for all configured platforms
-brownfield codegen -p swift          # Generate Swift only
-brownfield codegen --platform kotlin # Generate Kotlin only (coming soon)
-brownfield --help                    # Show help
-brownfield --version                 # Show version
+brownfield codegen          # Generate for all configured platforms
+brownfield codegen -p swift # Generate Swift only
+brownfield --help           # Show help
+brownfield --version        # Show version
 ```
 
 ## Configuration
 
-Add to your app's `package.json`:
-
-```json
-{
-  "brownie": {
-    "kotlin": "./android/app/src/main/java/com/example/",
-    "kotlinPackageName": "com.example"
-  }
-}
-```
-
-Note: This config is subject to change as Android support is rolled out. Ideally this will be removed in favor of auto-detection.
-
-| Field               | Required | Description                                                |
-| ------------------- | -------- | ---------------------------------------------------------- |
-| `kotlin`            | No       | Output directory for Kotlin files                          |
-| `kotlinPackageName` | No       | Kotlin package name (extracted from path if not specified) |
-
-**Note:** Swift files are always generated to `node_modules/@callstack/brownie/ios/Generated/`. This path is auto-resolved and not configurable.
+Swift files are always generated to `node_modules/@callstack/brownie/ios/Generated/`. This path is auto-resolved and not configurable.
 
 ## Generated Output
 
@@ -73,21 +54,6 @@ The generated struct:
 - Conforms to `BrownieStoreProtocol` with auto-generated `storeName`
 - Uses mutable `var` properties
 
-### Kotlin Output (Coming Soon)
-
-```kotlin
-package com.example
-
-data class BrownfieldStore(
-    val counter: Double,
-    val user: User
-)
-
-data class User(
-    val name: String
-)
-```
-
 ## Auto-Generation Hooks
 
 ### iOS (Podfile)
@@ -98,17 +64,6 @@ Run codegen before pod install:
 pre_install do |installer|
   system("npx", "brownie", "codegen", "-p", "swift")
 end
-```
-
-### Android (build.gradle.kts)
-
-Run codegen before build:
-
-```kotlin
-tasks.register("generateBrownfieldStore") {
-  exec { commandLine("npx", "brownie", "codegen", "-p", "kotlin") }
-}
-preBuild.dependsOn("generateBrownfieldStore")
 ```
 
 ## How It Works

--- a/docs/docs/docs/cli/brownie.mdx
+++ b/docs/docs/docs/cli/brownie.mdx
@@ -5,34 +5,11 @@ The `brownfield codegen` CLI command generates `@callstack/brownie` (Brownie) st
 ## Usage
 
 ```bash
-brownfield codegen                   # Generate for all configured platforms
-brownfield codegen -p swift          # Generate Swift only
-brownfield codegen --platform kotlin # Generate Kotlin only
-brownfield codegen --help            # Show help for Brownie state management codegen
-brownfield --version                 # Show version
+brownfield codegen          # Generate Swift types
+brownfield codegen -p swift # Generate Swift only
+brownfield codegen --help   # Show help for Brownie state management codegen
+brownfield --version        # Show version
 ```
-
-## Configuration
-
-Add to your app's `package.json`:
-
-```json
-{
-  "brownie": {
-    "swift": "./ios/Generated/",
-    "kotlin": "./android/app/src/main/java/com/example/",
-    "kotlinPackageName": "com.example"
-  }
-}
-```
-
-| Field               | Required | Description                               |
-| ------------------- | -------- | ----------------------------------------- |
-| `swift`             | No\*     | Output directory for Swift files          |
-| `kotlin`            | No\*     | Output directory for Kotlin files         |
-| `kotlinPackageName` | No       | Kotlin package name (extracted from path) |
-
-\*At least one of `swift` or `kotlin` is required.
 
 ## Store Definition
 
@@ -91,17 +68,7 @@ struct BrownfieldStore: Codable {
 }
 ```
 
-**Kotlin** (data class):
-
-```kotlin
-package com.example
-
-data class BrownfieldStore (
-    val counter: Double,
-    val isLoading: Boolean,
-    val user: String
-)
-```
+Swift files are always generated to `node_modules/@callstack/brownie/ios/Generated/`. This path is auto-resolved and not configurable.
 
 ### Store Discovery
 
@@ -127,7 +94,5 @@ JSON Schema
        ▼
 quicktype-core
        │
-       ├──▶ Swift (lang: 'swift', mutable-properties: true)
-       │
-       └──▶ Kotlin (lang: 'kotlin', framework: 'just-types')
+       └──▶ Swift (lang: 'swift', mutable-properties: true)
 ```

--- a/packages/cli/src/brownie/__tests__/commands/codegen.test.ts
+++ b/packages/cli/src/brownie/__tests__/commands/codegen.test.ts
@@ -92,7 +92,7 @@ describe('runCodegen', () => {
     expect(mockGenerateKotlin).not.toHaveBeenCalled();
   });
 
-  it('generates kotlin files for discovered store', async () => {
+  it('generates kotlin files when platform is kotlin', async () => {
     tempDir = createTempPackageJson({
       brownie: {
         kotlin: './Generated',
@@ -101,7 +101,7 @@ describe('runCodegen', () => {
     });
     mockCwd.mockReturnValue(tempDir);
 
-    await runCodegen({});
+    await runCodegen({ platform: 'kotlin' });
 
     expect(mockGenerateKotlin).toHaveBeenCalledWith({
       name: 'TestStore',
@@ -110,10 +110,10 @@ describe('runCodegen', () => {
       outputPath: 'Generated/TestStore.kt',
       packageName: 'com.test',
     });
-    expect(mockGenerateSwift).toHaveBeenCalled();
+    expect(mockGenerateSwift).not.toHaveBeenCalled();
   });
 
-  it('generates both swift and kotlin when configured', async () => {
+  it('generates only swift by default even when kotlin is configured', async () => {
     tempDir = createTempPackageJson({
       brownie: {
         kotlin: './Generated',
@@ -124,7 +124,7 @@ describe('runCodegen', () => {
     await runCodegen({});
 
     expect(mockGenerateSwift).toHaveBeenCalled();
-    expect(mockGenerateKotlin).toHaveBeenCalled();
+    expect(mockGenerateKotlin).not.toHaveBeenCalled();
   });
 
   it('generates only specified platform', async () => {
@@ -172,19 +172,6 @@ describe('runCodegen', () => {
     });
   });
 
-  it('exits with error for invalid platform', async () => {
-    tempDir = createTempPackageJson({
-      brownie: {},
-    });
-    mockCwd.mockReturnValue(tempDir);
-
-    // @ts-expect-error - testing invalid input
-    await expect(runCodegen({ platform: 'invalid' })).rejects.toThrow(
-      'process.exit(1)'
-    );
-    expect(mockLoggerError).toHaveBeenCalled();
-  });
-
   it('exits with error when generator fails', async () => {
     tempDir = createTempPackageJson({
       brownie: {},
@@ -205,5 +192,14 @@ describe('runCodegen', () => {
     await runCodegen({ platform: 'kotlin' });
 
     expect(mockGenerateKotlin).not.toHaveBeenCalled();
+  });
+
+  it('works without brownie config in package.json', async () => {
+    tempDir = createTempPackageJson({});
+    mockCwd.mockReturnValue(tempDir);
+
+    await runCodegen({});
+
+    expect(mockGenerateSwift).toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/brownie/__tests__/config.test.ts
+++ b/packages/cli/src/brownie/__tests__/config.test.ts
@@ -43,12 +43,11 @@ describe('loadConfig', () => {
     expect(() => loadConfig()).toThrow('package.json not found');
   });
 
-  it('throws when brownie config missing', () => {
+  it('returns empty config when brownie config missing', () => {
     tempDir = createTempPackageJson({});
     mockCwd.mockReturnValue(tempDir);
-    expect(() => loadConfig()).toThrow(
-      'brownie config not found in package.json'
-    );
+    const config = loadConfig();
+    expect(config).toEqual({});
   });
 
   it('loads empty config', () => {

--- a/packages/cli/src/brownie/commands/codegen.ts
+++ b/packages/cli/src/brownie/commands/codegen.ts
@@ -114,10 +114,8 @@ export async function runCodegen({ platform }: RunCodegenOptions) {
     if (platform) {
       platforms = [platform];
     } else {
+      // Only generate Swift by default (Kotlin not yet released)
       platforms = ['swift'];
-      if (config.kotlin) {
-        platforms.push('kotlin');
-      }
     }
 
     await generateForStore(store, config, platforms, isMultipleStores);
@@ -131,8 +129,8 @@ export const codegenCommand = new Command('codegen')
   .addOption(
     new Option(
       '-p, --platform <platform>',
-      'Generate for specific platform (swift, kotlin)'
-    ).choices(['swift', 'kotlin'])
+      'Generate for specific platform (swift)'
+    ).choices(['swift'])
   )
   .action(
     actionRunner(async (options: RunCodegenOptions) => {

--- a/packages/cli/src/brownie/config.ts
+++ b/packages/cli/src/brownie/config.ts
@@ -67,11 +67,5 @@ export function loadConfig(): BrownieConfig {
   const packageJson: PackageJson = JSON.parse(
     fs.readFileSync(packageJsonPath, 'utf-8')
   );
-  const config = packageJson.brownie;
-
-  if (!config) {
-    throw new Error('brownie config not found in package.json');
-  }
-
-  return config;
+  return packageJson.brownie ?? {};
 }


### PR DESCRIPTION
## Summary

- Hide Kotlin codegen from CLI until ready for release (still accessible via explicit `-p kotlin`)
- Make `brownie` config in package.json optional (Swift output path is auto-resolved)
- Update docs to remove unreleased Kotlin references
- Update tests for new default behavior