### PR TITLE
feat(brownie): add static register method to BrownieStoreProtocol

### DIFF
--- a/apps/AppleApp/Brownfield Apple App/BrownfieldAppleApp.swift
+++ b/apps/AppleApp/Brownfield Apple App/BrownfieldAppleApp.swift
@@ -16,8 +16,8 @@ struct BrownfieldAppleApp: App {
         ReactNativeBrownfield.shared.startReactNative {
             print("React Native has been loaded")
         }
-        
-        _ = Store(initialState, key: BrownfieldStore.storeName)
+
+        BrownfieldStore.register(initialState)
     }
 
     var body: some Scene {

--- a/apps/TesterIntegrated/swift/App.swift
+++ b/apps/TesterIntegrated/swift/App.swift
@@ -21,7 +21,7 @@ struct MyApp: App {
       print("loaded")
     }
 
-    _ = Store(initialState, key: BrownfieldStore.storeName)
+    BrownfieldStore.register(initialState)
   }
 
   var body: some Scene {

--- a/docs/docs/brownie/codegen.mdx
+++ b/docs/docs/brownie/codegen.mdx
@@ -54,17 +54,6 @@ The generated struct:
 - Conforms to `BrownieStoreProtocol` with auto-generated `storeName`
 - Uses mutable `var` properties
 
-## Auto-Generation Hooks
-
-### iOS (Podfile)
-
-Run codegen before pod install:
-
-```ruby
-pre_install do |installer|
-  system("npx", "brownie", "codegen", "-p", "swift")
-end
-```
 
 ## How It Works
 

--- a/docs/docs/brownie/overview.mdx
+++ b/docs/docs/brownie/overview.mdx
@@ -43,18 +43,6 @@ npm install @callstack/brownie
 yarn add @callstack/brownie
 ```
 
-### iOS Setup
-
-Add to your `Podfile`:
-
-```ruby
-pre_install do |installer|
-  system("npx", "brownfield", "codegen", "-p", "swift")
-end
-```
-
-Then run `pod install`.
-
 ## Quick Example
 
 **TypeScript (store definition):**

--- a/docs/docs/brownie/swift-usage.mdx
+++ b/docs/docs/brownie/swift-usage.mdx
@@ -28,8 +28,8 @@ struct MyApp: App {
       print("React Native loaded")
     }
 
-    // Initialize store with initial state
-    _ = Store(initialState, key: BrownfieldStore.storeName)
+    // Register store with initial state
+    BrownfieldStore.register(initialState)
   }
 
   var body: some Scene {
@@ -287,3 +287,10 @@ $counter.set { $0 + 1 }  // increment using current value
 | `StoreManager.get(key:as:)` | Retrieve typed store by key |
 | `shared.snapshot(key:)`     | Get raw snapshot dictionary |
 | `shared.removeStore(key:)`  | Remove and cleanup store    |
+
+### BrownieStoreProtocol
+
+| Method         | Description                           |
+| -------------- | ------------------------------------- |
+| `register(_:)` | Register store with initial state     |
+| `storeName`    | Static property with store identifier |

--- a/packages/brownie/ArchitectureOverview.md
+++ b/packages/brownie/ArchitectureOverview.md
@@ -246,6 +246,11 @@ packages/brownie/
 - Observes `BrownieStoreUpdated` notification, rebuilds typed state from C++ snapshot
 - `deinit` removes notification observer
 
+**BrownieStoreProtocol** - Protocol for generated store types:
+
+- `storeName` - Static property with store identifier
+- `register(_:)` - Static method to register store with initial state (extension method)
+
 **StoreManager** - Swift-side registry (delegates to C++):
 
 - `register(store:key:)` - Register Swift store
@@ -406,22 +411,3 @@ The ObjC++ bridge layer has the most room for optimization:
 - **Single-property sync** - Currently `pushStateToCxx()` serializes entire state. Could track dirty properties and only sync changed values.
 - **Lazy Swift state rebuild** - Defer `Codable` struct reconstruction until property actually accessed.
 - **Direct C++ ↔ Swift interop** - Swift 5.9+ has experimental C++ interop that could bypass ObjC++ bridge entirely.
-
-## Auto-generation Hooks
-
-### iOS (Podfile)
-
-```ruby
-pre_install do |installer|
-  system("npx", "brownie", "codegen", "-p", "swift")
-end
-```
-
-### Android (build.gradle.kts)
-
-```kotlin
-tasks.register("generateBrownfieldStore") {
-  exec { commandLine("npx", "brownie", "codegen", "-p", "kotlin") }
-}
-preBuild.dependsOn("generateBrownfieldStore")
-```

--- a/packages/brownie/ios/BrownieStore.swift
+++ b/packages/brownie/ios/BrownieStore.swift
@@ -10,6 +10,13 @@ public protocol BrownieStoreProtocol: Codable {
   static var storeName: String { get }
 }
 
+public extension BrownieStoreProtocol {
+  /// Registers the store with the given initial state.
+  static func register(_ initialState: Self) {
+    _ = Store(initialState, key: Self.storeName)
+  }
+}
+
 public struct StoreKey<State: Codable>: EnvironmentKey {
   public static var defaultValue: Store<State> { fatalError("Store not provided") }
 }


### PR DESCRIPTION
## Summary

- Add `register(_:)` static method to `BrownieStoreProtocol` for cleaner store initialization
- Replace verbose `_ = Store(initialState, key: BrownfieldStore.storeName)` with `BrownfieldStore.register(initialState)`
- Update docs and example apps to use new API