### PR TITLE
docs(brownie): add getting started guide with XCFramework flow

### DIFF
--- a/docs/docs/brownie/_meta.json
+++ b/docs/docs/brownie/_meta.json
@@ -6,6 +6,11 @@
   },
   {
     "type": "file",
+    "name": "getting-started",
+    "label": "Getting Started"
+  },
+  {
+    "type": "file",
     "name": "store-definition",
     "label": "Defining Stores"
   },

--- a/docs/docs/brownie/getting-started.mdx
+++ b/docs/docs/brownie/getting-started.mdx
@@ -1,0 +1,151 @@
+# Getting Started
+
+This guide walks you through setting up Brownie from scratch - defining stores, generating native types, building XCFrameworks, and using shared state in both React Native and Swift.
+
+## Prerequisites
+
+Before starting, ensure you have:
+
+- Completed the [React Native Brownfield Quick Start](/docs/getting-started/quick-start) guide
+- React Native project with `@callstack/react-native-brownfield` installed
+- Native iOS app (SwiftUI or UIKit)
+- Xcode 15+
+
+## Step 1: Install Brownie
+
+In your React Native project:
+
+```bash
+npm install @callstack/brownie
+```
+
+## Step 2: Define Your Store
+
+Create a store definition file with the `.brownie.ts` extension:
+
+```ts
+// src/stores/AppStore.brownie.ts
+import type { BrownieStore } from '@callstack/brownie';
+
+interface AppStore extends BrownieStore {
+  counter: number;
+}
+
+declare module '@callstack/brownie' {
+  interface BrownieStores {
+    AppStore: AppStore;
+  }
+}
+```
+
+Import the store in your app entry point:
+
+```ts
+// App.tsx
+import './stores/AppStore.brownie';
+```
+
+## Step 3: Use the Store in React Native
+
+```tsx
+import { useStore } from '@callstack/brownie';
+
+function Counter() {
+  const [counter, setState] = useStore('AppStore', (s) => s.counter);
+
+  return (
+    <View>
+      <Text>Count: {counter}</Text>
+      <Button
+        title="Increment"
+        onPress={() => setState((prev) => ({ counter: prev.counter + 1 }))}
+      />
+    </View>
+  );
+}
+```
+
+## Step 4: Build XCFrameworks
+
+The CLI generates native types and builds everything into XCFrameworks:
+
+```bash
+npx brownfield package:ios --scheme YourScheme --configuration Release
+```
+
+This produces the following in `ios/.brownfield/package/`:
+
+- `YourScheme.xcframework` - Your React Native module
+- `Brownie.xcframework` - Shared state library
+- `ReactBrownfield.xcframework` - Brownfield integration
+- `hermesvm.xcframework` - JavaScript engine (or `hermes.xcframework` for RN < 0.82.0)
+
+:::info
+The `package:ios` command automatically runs `brownfield codegen` to generate Swift types from your `.brownie.ts` files.
+:::
+
+## Step 5: Add Frameworks to Native App
+
+1. Open your native Xcode project
+2. Drag all XCFrameworks from `ios/.brownfield/package/` into your project
+3. In target settings → **General** → **Frameworks, Libraries, and Embedded Content**, set all to **Embed & Sign**
+
+## Step 6: Register Store in Swift
+
+In your app's entry point, register the store with initial state:
+
+```swift
+import Brownie
+import ReactBrownfield
+import SwiftUI
+
+let initialState = AppStore(counter: 0)
+
+@main
+struct MyApp: App {
+  init() {
+    ReactNativeBrownfield.shared.startReactNative {
+      print("React Native loaded")
+    }
+
+    AppStore.register(initialState)
+  }
+
+  var body: some Scene {
+    WindowGroup {
+      ContentView()
+    }
+  }
+}
+```
+
+## Step 7: Use the Store in SwiftUI
+
+```swift
+import Brownie
+import SwiftUI
+
+struct CounterView: View {
+  @UseStore(\AppStore.counter) var counter
+
+  var body: some View {
+    VStack {
+      Text("Count: \(Int(counter))")
+      Button("Increment") {
+        $counter.set { $0 + 1 }
+      }
+    }
+  }
+}
+```
+
+## Done!
+
+State changes now sync automatically between React Native and Swift. Increment from either side and both update immediately.
+
+## Next Steps
+
+- [Defining Stores](/brownie/store-definition) - Nested objects and multiple stores
+- [TypeScript Usage](/brownie/typescript-usage) - Advanced React Native patterns
+- [Swift Usage](/brownie/swift-usage) - UIKit integration and API reference
+- [XCFramework Packaging](/brownie/xcframework-packaging) - SPM distribution and advanced options

--- a/docs/docs/brownie/overview.mdx
+++ b/docs/docs/brownie/overview.mdx
@@ -32,75 +32,12 @@ Brownie is a shared state management library for React Native brownfield apps. I
 
 1. Define your store shape in a `*.brownie.ts` file using TypeScript
 2. Run `brownfield codegen` to generate native types
-3. Use `useStore` in React Native and `Store<T>` in Swift
+3. Use `useStore` in React Native and `@UseStore` in Swift
 4. State changes sync automatically between both sides
-
-## Installation
-
-```bash
-npm install @callstack/brownie
-# or
-yarn add @callstack/brownie
-```
-
-## Quick Example
-
-**TypeScript (store definition):**
-
-```ts
-// BrownfieldStore.brownie.ts
-import type { BrownieStore } from '@callstack/brownie';
-
-interface AppStore extends BrownieStore {
-  counter: number;
-  user: { name: string };
-}
-
-declare module '@callstack/brownie' {
-  interface BrownieStores {
-    AppStore: AppStore;
-  }
-}
-```
-
-**TypeScript (usage):**
-
-```tsx
-import { useStore } from '@callstack/brownie';
-
-function Counter() {
-  const [counter, setState] = useStore('AppStore', (s) => s.counter);
-
-  return (
-    <Button
-      title={`Count: ${counter}`}
-      onPress={() => setState((prev) => ({ counter: prev.counter + 1 }))}
-    />
-  );
-}
-```
-
-**Swift (usage):**
-
-```swift
-import Brownie
-
-struct ContentView: View {
-  @UseStore(\AppStore.counter) var counter
-
-  var body: some View {
-    VStack {
-      Text("Count: \(Int(counter))")
-      Button("Increment") {
-        $counter.set { $0 + 1 }
-      }
-    }
-  }
-}
-```
 
 ## Next Steps
 
+- [Getting Started](/brownie/getting-started) - Step-by-step setup guide
 - [Defining Stores](/brownie/store-definition) - Learn how to define your store schema
 - [Code Generation](/brownie/codegen) - Configure and run the codegen CLI
 - [TypeScript Usage](/brownie/typescript-usage) - Use stores in React Native

--- a/docs/docs/brownie/xcframework-packaging.mdx
+++ b/docs/docs/brownie/xcframework-packaging.mdx
@@ -13,6 +13,8 @@ Running `npx brownfield package:ios` produces the following XCFrameworks in `ios
 
 The consumer app needs to embed all 4 frameworks when using Brownie.
 
+Note: This command also takes care of running `brownfield codegen` for you.
+
 ## Integration Options
 
 ### Drag and Drop


### PR DESCRIPTION
## Summary

- Add comprehensive "Getting Started" guide for Brownie with complete XCFramework workflow
- Simplify overview page to focus on what Brownie is (moved examples to getting started)
- Link to main brownfield Quick Start as prerequisite
- Update navigation to include new page