### PR TITLE
feat(android): allow bundle file path

### DIFF
--- a/packages/react-native-brownfield/android/src/main/java/com/callstack/reactnativebrownfield/ReactNativeBrownfield.kt
+++ b/packages/react-native-brownfield/android/src/main/java/com/callstack/reactnativebrownfield/ReactNativeBrownfield.kt
@@ -73,14 +73,14 @@ class ReactNativeBrownfield private constructor(val reactHost: ReactHost) {
         ) {
             val reactHost: ReactHost by lazy {
                 val bundlePath = options["bundleAssetPath"] as? String ?: "index.android.bundle"
-                val isFilePath = bundlePath.startsWith("/") || bundlePath.startsWith("file://")
+                val isFilePath = bundlePath.startsWith("/") || bundlePath.startsWith("file://") || bundlePath.startsWith("assets://")
 
                 getDefaultReactHost(
                     context = application,
                     packageList = (options["packages"] as? List<*> ?: emptyList<ReactPackage>())
                         .filterIsInstance<ReactPackage>(),
                     jsMainModulePath = options["mainModuleName"] as? String ?: "index",
-                    jsBundleAssetPath = if (isFilePath) "index.android.bundle" else bundlePath,
+                    jsBundleAssetPath = bundlePath,
                     jsBundleFilePath = if (isFilePath) bundlePath else null,
                     useDevSupport = options["useDeveloperSupport"] as? Boolean
                         ?: ReactBuildConfig.DEBUG,


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary


https://discord.com/channels/426714625279524876/1460917572894457968/1461699896594792677

I’m integrating HotUpdater. After an OTA update, HotUpdater uses the bundle from the file system.

Return values of `HotUpdater.getJSBundleFile()`:


**Without an OTA bundle (initial state):**
"assets://index.android.bundle"


**With an OTA bundle:**
"/storage/emulated/0/Android/data/com.callstack.brownfield.android.example/files/bundle-store/019bc77b-d454-7ccd-9d39-721800a3026d/index.android.bundle"


Therefore, when the app is closed and reopened, file path access also needs to be allowed.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan


1. fork example and change this code

```tsx
package com.rnapp.brownfieldlib

import android.app.Application
import com.callstack.reactnativebrownfield.OnJSBundleLoaded
import com.callstack.reactnativebrownfield.ReactNativeBrownfield
import com.facebook.react.PackageList
import com.facebook.react.ReactNativeApplicationEntryPoint.loadReactNative
import com.hotupdater.HotUpdater

object ReactNativeHostManager {
    fun initialize(application: Application, onJSBundleLoaded: OnJSBundleLoaded? = null) {
        loadReactNative(application)

        val packageList = PackageList(application).packages
        val options = hashMapOf<String, Any>(
            "packages" to packageList,
            "mainModuleName" to "index",
            "bundleAssetPath" to HotUpdater.getJSBundleFile(application),
            "useDeveloperSupport" to false
        )

        ReactNativeBrownfield.initialize(application, options) { initialized ->
            // Set ReactHost in HotUpdater after initialization
            HotUpdater.setReactHost(ReactNativeBrownfield.shared.reactHost)
            onJSBundleLoaded?.invoke(initialized)
        }
    }

    fun destroy() {
        HotUpdater.clearReactHost()
    }
}

```


https://github.com/user-attachments/assets/30d6c26a-816f-4212-8926-ee71032d808c



<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
