### PR TITLE
fix(brownie): throw descriptive error when store not registered

### DIFF
--- a/packages/brownie/src/index.ts
+++ b/packages/brownie/src/index.ts
@@ -30,9 +30,18 @@ function getOrCreateStore(key: string): StoreCache {
   let store = stores.get(key);
   if (!store) {
     const hostObject = getHostObject(key);
+    if (!hostObject) {
+      throw new Error(
+        `[Brownie] Store "${key}" not found. ` +
+          `Make sure to register it on the native side before accessing it from JS.\n\n` +
+          `Swift example:\n` +
+          `  ${key}.register(${key}(...))\n\n` +
+          `This should be called before React Native starts.`
+      );
+    }
     store = {
       hostObject,
-      snapshot: hostObject?.unbox?.() ?? {},
+      snapshot: hostObject.unbox?.() ?? {},
       listeners: new Set(),
     };
     stores.set(key, store);
@@ -85,7 +94,6 @@ export function setState<K extends keyof BrownieStores>(
   action: SetStateAction<BrownieStores[K]>
 ): void {
   const store = getOrCreateStore(key as string);
-  if (!store.hostObject) return;
 
   const partial =
     typeof action === 'function'


### PR DESCRIPTION
## Summary

- Improves error handling when a Brownie store is accessed from JS but not registered on native side
- Throws descriptive error with Swift code example showing how to fix

## Changes

When `getOrCreateStore()` is called for a store that wasn't registered natively, it now throws:

```
[Brownie] Store "BrownfieldStore" not found. Make sure to register it on the native side before accessing it from JS.

Swift example:
  BrownfieldStore.register(BrownfieldStore(...))

This should be called before React Native starts.
```

Previously, this would silently return empty objects leading to confusing behavior.