### PR TITLE
feat(cli): strip framework binaries to avoid duplicate symbol errors

### DIFF
--- a/packages/cli/src/brownfield/commands/packageIos.ts
+++ b/packages/cli/src/brownfield/commands/packageIos.ts
@@ -17,7 +17,7 @@ import { Command } from 'commander';
 
 import { isBrownieInstalled } from '../../brownie/config.js';
 import { runCodegen } from '../../brownie/commands/codegen.js';
-import { getProjectInfo } from '../utils/index.js';
+import { getProjectInfo, stripFrameworkBinary } from '../utils/index.js';
 import {
   actionRunner,
   curryOptions,
@@ -100,6 +100,11 @@ export const packageIosCommand = curryOptions(
         ],
         outputPath: brownieOutputPath,
       });
+
+      // Strip the binary from Brownie.xcframework to make it interface-only.
+      // This avoids duplicate symbols when consumer apps embed both BrownfieldLib
+      // (which contains Brownie symbols) and Brownie.xcframework.
+      await stripFrameworkBinary(brownieOutputPath);
 
       logger.success(
         `Brownie.xcframework created at ${colorLink(relativeToCwd(brownieOutputPath))}`

--- a/packages/cli/src/brownfield/utils/__tests__/strip-framework-binary.test.ts
+++ b/packages/cli/src/brownfield/utils/__tests__/strip-framework-binary.test.ts
@@ -1,0 +1,180 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execSync } from 'node:child_process';
+
+import * as rockTools from '@rock-js/tools';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { stripFrameworkBinary } from '../stripFrameworkBinary.js';
+
+vi.mock('@rock-js/tools', async (importOriginal) => {
+  const actual = await importOriginal<typeof rockTools>();
+  return {
+    ...actual,
+    logger: {
+      ...actual.logger,
+      error: vi.fn(),
+      warn: vi.fn(),
+      info: vi.fn(),
+      success: vi.fn(),
+      debug: vi.fn(),
+    },
+  };
+});
+
+const mockLoggerWarn = rockTools.logger.warn as ReturnType<typeof vi.fn>;
+const mockLoggerSuccess = rockTools.logger.success as ReturnType<typeof vi.fn>;
+
+function createMockXcframework(
+  baseDir: string,
+  name: string,
+  slices: string[]
+): string {
+  const xcframeworkPath = path.join(baseDir, `${name}.xcframework`);
+  fs.mkdirSync(xcframeworkPath, { recursive: true });
+
+  for (const slice of slices) {
+    const frameworkDir = path.join(xcframeworkPath, slice, `${name}.framework`);
+    fs.mkdirSync(frameworkDir, { recursive: true });
+
+    const binaryPath = path.join(frameworkDir, name);
+    fs.writeFileSync(binaryPath, 'fake binary content for testing');
+  }
+
+  return xcframeworkPath;
+}
+
+describe('stripFrameworkBinary', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'strip-framework-test-'));
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('throws when xcframework does not exist', () => {
+    const nonExistentPath = path.join(tempDir, 'NonExistent.xcframework');
+
+    expect(() => stripFrameworkBinary(nonExistentPath)).toThrow(
+      'XCFramework not found at:'
+    );
+  });
+
+  it('strips binary from ios-arm64 slice', () => {
+    const xcframeworkPath = createMockXcframework(tempDir, 'TestFramework', [
+      'ios-arm64',
+    ]);
+    const binaryPath = path.join(
+      xcframeworkPath,
+      'ios-arm64',
+      'TestFramework.framework',
+      'TestFramework'
+    );
+    const originalContent = fs.readFileSync(binaryPath, 'utf-8');
+
+    stripFrameworkBinary(xcframeworkPath);
+
+    const newContent = fs.readFileSync(binaryPath);
+    expect(newContent.toString()).not.toBe(originalContent);
+    expect(fs.existsSync(binaryPath)).toBe(true);
+    expect(mockLoggerSuccess).toHaveBeenCalledWith(
+      'TestFramework.xcframework is now interface-only'
+    );
+  });
+
+  it('strips binary from simulator slice with fat binary', () => {
+    const xcframeworkPath = createMockXcframework(tempDir, 'TestFramework', [
+      'ios-arm64_x86_64-simulator',
+    ]);
+    const binaryPath = path.join(
+      xcframeworkPath,
+      'ios-arm64_x86_64-simulator',
+      'TestFramework.framework',
+      'TestFramework'
+    );
+    const originalContent = fs.readFileSync(binaryPath, 'utf-8');
+
+    stripFrameworkBinary(xcframeworkPath);
+
+    const newContent = fs.readFileSync(binaryPath);
+    expect(newContent.toString()).not.toBe(originalContent);
+
+    const archInfo = execSync(`xcrun lipo -info "${binaryPath}"`, {
+      encoding: 'utf-8',
+    });
+    expect(archInfo).toContain('arm64');
+    expect(archInfo).toContain('x86_64');
+  });
+
+  it('handles multiple slices', () => {
+    const xcframeworkPath = createMockXcframework(tempDir, 'TestFramework', [
+      'ios-arm64',
+      'ios-arm64_x86_64-simulator',
+    ]);
+
+    stripFrameworkBinary(xcframeworkPath);
+
+    const deviceBinary = path.join(
+      xcframeworkPath,
+      'ios-arm64',
+      'TestFramework.framework',
+      'TestFramework'
+    );
+    const simBinary = path.join(
+      xcframeworkPath,
+      'ios-arm64_x86_64-simulator',
+      'TestFramework.framework',
+      'TestFramework'
+    );
+
+    expect(fs.existsSync(deviceBinary)).toBe(true);
+    expect(fs.existsSync(simBinary)).toBe(true);
+    expect(mockLoggerSuccess).toHaveBeenCalledOnce();
+  });
+
+  it('warns and skips unknown slice types', () => {
+    const xcframeworkPath = createMockXcframework(tempDir, 'TestFramework', [
+      'ios-unknown-slice',
+    ]);
+
+    stripFrameworkBinary(xcframeworkPath);
+
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      'Unknown slice type: ios-unknown-slice, skipping'
+    );
+  });
+
+  it('warns and skips slices without binary', () => {
+    const xcframeworkPath = path.join(tempDir, 'TestFramework.xcframework');
+    const frameworkDir = path.join(
+      xcframeworkPath,
+      'ios-arm64',
+      'TestFramework.framework'
+    );
+    fs.mkdirSync(frameworkDir, { recursive: true });
+
+    stripFrameworkBinary(xcframeworkPath);
+
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.stringContaining('No binary found at')
+    );
+  });
+
+  it('ignores non-ios directories', () => {
+    const xcframeworkPath = createMockXcframework(tempDir, 'TestFramework', [
+      'ios-arm64',
+    ]);
+    fs.mkdirSync(path.join(xcframeworkPath, 'macos-arm64'), {
+      recursive: true,
+    });
+
+    stripFrameworkBinary(xcframeworkPath);
+
+    expect(mockLoggerSuccess).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/cli/src/brownfield/utils/index.ts
+++ b/packages/cli/src/brownfield/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './paths.js';
 export * from './rn-cli.js';
+export * from './stripFrameworkBinary.js';

--- a/packages/cli/src/brownfield/utils/stripFrameworkBinary.ts
+++ b/packages/cli/src/brownfield/utils/stripFrameworkBinary.ts
@@ -1,0 +1,149 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execSync } from 'node:child_process';
+import { logger } from '@rock-js/tools';
+
+interface SliceConfig {
+  target: string;
+  /** Additional targets for fat binaries */
+  additionalTargets?: string[];
+}
+
+const SLICE_CONFIGS: Record<string, SliceConfig> = {
+  'ios-arm64': {
+    target: 'arm64-apple-ios15.0',
+  },
+  'ios-arm64_x86_64-simulator': {
+    target: 'arm64-apple-ios15.0-simulator',
+    additionalTargets: ['x86_64-apple-ios15.0-simulator'],
+  },
+};
+
+/**
+ * Creates an empty static library for the given target.
+ */
+function createEmptyStaticLib(target: string): string {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'framework-strip-'));
+  const tempObj = path.join(tempDir, 'empty.o');
+  const tempLib = path.join(tempDir, 'empty.a');
+
+  try {
+    execSync(
+      `echo "" | xcrun clang -x c -c - -o "${tempObj}" -target ${target}`,
+      {
+        stdio: 'pipe',
+      }
+    );
+
+    execSync(`xcrun ar rcs "${tempLib}" "${tempObj}"`, {
+      stdio: 'pipe',
+    });
+  } catch (error) {
+    fs.rmSync(tempDir, { recursive: true });
+    throw new Error(
+      `Failed to create empty static library for target ${target}: ${error instanceof Error ? error.message : error}`
+    );
+  }
+
+  fs.unlinkSync(tempObj);
+
+  return tempLib;
+}
+
+/**
+ * Creates a fat static library combining multiple architectures.
+ */
+function createFatStaticLib(targets: string[]): string {
+  const libs = targets.map((target) => createEmptyStaticLib(target));
+
+  const outputDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'framework-strip-fat-')
+  );
+  const outputLib = path.join(outputDir, 'fat.a');
+
+  try {
+    execSync(
+      `xcrun lipo -create ${libs.map((l) => `"${l}"`).join(' ')} -output "${outputLib}"`,
+      {
+        stdio: 'pipe',
+      }
+    );
+  } catch (error) {
+    libs.forEach((lib) => fs.rmSync(path.dirname(lib), { recursive: true }));
+    fs.rmSync(outputDir, { recursive: true });
+    throw new Error(
+      `Failed to create fat static library: ${error instanceof Error ? error.message : error}`
+    );
+  }
+
+  libs.forEach((lib) => {
+    fs.unlinkSync(lib);
+    fs.rmSync(path.dirname(lib), { recursive: true });
+  });
+
+  return outputLib;
+}
+
+/**
+ * Strips the binary from an xcframework, keeping only Swift module interfaces.
+ * This creates an "interface-only" framework where consumers can import the module
+ * but the actual symbols must come from another framework (e.g., BrownfieldLib).
+ *
+ * @param xcframeworkPath - Path to the .xcframework directory
+ */
+export function stripFrameworkBinary(xcframeworkPath: string): void {
+  if (!fs.existsSync(xcframeworkPath)) {
+    throw new Error(`XCFramework not found at: ${xcframeworkPath}`);
+  }
+
+  const frameworkName = path.basename(xcframeworkPath, '.xcframework');
+
+  logger.info(
+    `Stripping binary from ${frameworkName}.xcframework (interface-only)...`
+  );
+
+  const slices = fs.readdirSync(xcframeworkPath).filter((entry) => {
+    const fullPath = path.join(xcframeworkPath, entry);
+    return fs.statSync(fullPath).isDirectory() && entry.startsWith('ios-');
+  });
+
+  for (const sliceName of slices) {
+    const frameworkDir = path.join(
+      xcframeworkPath,
+      sliceName,
+      `${frameworkName}.framework`
+    );
+    const binaryPath = path.join(frameworkDir, frameworkName);
+
+    if (!fs.existsSync(binaryPath)) {
+      logger.warn(`No binary found at ${binaryPath}, skipping`);
+      continue;
+    }
+
+    const config = SLICE_CONFIGS[sliceName];
+    if (!config) {
+      logger.warn(`Unknown slice type: ${sliceName}, skipping`);
+      continue;
+    }
+
+    let emptyLib: string;
+    if (config.additionalTargets) {
+      // Create fat library for multiple architectures
+      emptyLib = createFatStaticLib([
+        config.target,
+        ...config.additionalTargets,
+      ]);
+    } else {
+      // Create single-arch library
+      emptyLib = createEmptyStaticLib(config.target);
+    }
+
+    // Replace original binary with empty stub
+    fs.copyFileSync(emptyLib, binaryPath);
+    fs.unlinkSync(emptyLib);
+    fs.rmSync(path.dirname(emptyLib), { recursive: true });
+  }
+
+  logger.success(`${frameworkName}.xcframework is now interface-only`);
+}


### PR DESCRIPTION
## Summary

- Add `stripFrameworkBinary` utility that replaces xcframework binaries with empty stubs while preserving Swift module interfaces
- This creates "interface-only" frameworks where consumers can import the module but actual symbols come from BrownfieldLib
- Prevents duplicate symbol linker errors when the same dependency is included in both the host app and brownfield package

## Changes

- New `stripFrameworkBinary.ts` utility with support for single-arch and fat (multi-arch) static libraries
- Updated `packageIos.ts` to use the stripping functionality
- Added `base64` gem dependency for RNApp