### PR TITLE
docs(brownie): remove unreleased notice from alpha warning

### DIFF
--- a/docs/docs/brownie/overview.mdx
+++ b/docs/docs/brownie/overview.mdx
@@ -1,7 +1,7 @@
 # Brownie
 
 :::warning Alpha
-Brownie is in alpha stage and not yet released. APIs may change.
+Brownie is in alpha stage. APIs may change.
 :::
 
 Brownie is a shared state management library for React Native brownfield apps. It enables seamless state synchronization between your React Native code and native code.


### PR DESCRIPTION
## Summary

- Remove "not yet released" text from Brownie alpha warning since the library is now released