### PR TITLE
fix(ios): remove brownie and react brownfield exported directives

### DIFF
--- a/packages/react-native-brownfield/src/expo-config-plugin/template/ios/FrameworkInterface.swift
+++ b/packages/react-native-brownfield/src/expo-config-plugin/template/ios/FrameworkInterface.swift
@@ -1,6 +1,5 @@
-// Export helpers from @callstack/react-native-brownfield library
 import Foundation
-@_exported import ReactBrownfield
+import ReactBrownfield
 
 // Initializes a Bundle instance that points at the framework target.
 public let ReactNativeBundle = Bundle(for: InternalClassForBundle.self)


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

This PR removes the need to re-export the `Brownie` and `ReactBrownfield` modules as they are already linked to the host App after the framework generation. This also fixes the bug where the user does not want to install `Brownie`, without this PR, they will have to install `Brownie` even if they don't use it.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

CI Passes - 🟢 
