### PR TITLE
docs: mention AppCompatActivity constraint with Expo

### DIFF
--- a/docs/docs/docs/getting-started/expo.mdx
+++ b/docs/docs/docs/getting-started/expo.mdx
@@ -88,7 +88,9 @@ override fun onConfigurationChanged(newConfig: Configuration) {
 
 > You can see the demo integration in [Android App](https://github.com/callstack/react-native-brownfield/blob/main/apps/AndroidApp/app/src/main/java/com/callstack/brownfield/android/example/MainActivity.kt) as well
 
-> Using the ComponentActivity does not work with Expo apps as Expo needs an instance of AppCompatActivity. There is a hard type assertion [here](https://github.com/expo/expo/blob/a2a3c04e5d946182b5aa9e312ef767879119c4bb/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt#L292)
+:::warning
+Using the ComponentActivity does not work with Expo Apps as Expo needs an instance of AppCompatActivity. There is a hard type assertion [here](https://github.com/expo/expo/blob/a2a3c04e5d946182b5aa9e312ef767879119c4bb/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt#L292)
+:::
 
 4. Build and install the android application 🚀
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

This adds a note to the expo docs, stating the constraint to use the `AppCompatActivity`. For example, a new bootstrapped project from Android Studio for JetPack compose will contain the `ComponentActivity` and using the generated Expo Brownfield AAR is not possible because Expo needs `AppCompatActivity` instead.

This only affects the native or host Android Apps, which consumes the AAR.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

N/A