### PR TITLE
(fix): restore back-button propagation from native to RN

### DIFF
--- a/.changeset/easy-aliens-tie.md
+++ b/.changeset/easy-aliens-tie.md
@@ -1,0 +1,5 @@
+---
+'@callstack/react-native-brownfield': patch
+---
+
+fix: restore back-button propagation from native to RN

--- a/packages/react-native-brownfield/android/src/main/java/com/callstack/reactnativebrownfield/ReactNativeBrownfield.kt
+++ b/packages/react-native-brownfield/android/src/main/java/com/callstack/reactnativebrownfield/ReactNativeBrownfield.kt
@@ -167,7 +167,7 @@ class ReactNativeBrownfield private constructor(val reactHost: ReactHost) {
         val resolvedDelegate =
             reactDelegate ?: ReactDelegateWrapper(activity, reactHost, moduleName, launchOptions)
 
-        val mBackPressedCallback: OnBackPressedCallback = object : OnBackPressedCallback(true) {
+        val backPressedCallback: OnBackPressedCallback = object : OnBackPressedCallback(true) {
             override fun handleOnBackPressed() {
                 // invoked for JS stack back navigation
                 resolvedDelegate.onBackPressed()
@@ -175,11 +175,12 @@ class ReactNativeBrownfield private constructor(val reactHost: ReactHost) {
         }
 
         // Register back press callback
-        activity?.onBackPressedDispatcher?.addCallback(mBackPressedCallback)
+        activity?.onBackPressedDispatcher?.addCallback(backPressedCallback)
         // invoked on the last RN screen exit
         resolvedDelegate.setHardwareBackHandler {
-            mBackPressedCallback.isEnabled = false
+            backPressedCallback.isEnabled = false
             activity?.onBackPressedDispatcher?.onBackPressed()
+            backPressedCallback.isEnabled = true
         }
 
         /**


### PR DESCRIPTION
### Summary

Address the _mBackPressedCallback not re-enabled after hardware back handler is called #227_ issue

### Test plan

|before| after|
|------|------|
|<video src="https://github.com/user-attachments/assets/edf9d9d6-1378-4bc5-9d5c-bc1f8610c928" controls="controls" muted="muted" style="max-width: 50%;"></video>|<video src="https://github.com/user-attachments/assets/72d89651-d8fe-470c-9787-655b74849c14" controls="controls" muted="muted" style="max-width: 50%;"></video>|