### PR TITLE
fix: duplicate symbols for ReactBrownfield

### DIFF
--- a/.changeset/strict-animals-worry.md
+++ b/.changeset/strict-animals-worry.md
@@ -1,0 +1,5 @@
+---
+'@callstack/brownfield-cli': patch
+---
+
+fix duplicate symbols for react-brownfield

--- a/packages/cli/src/brownfield/commands/packageIos.ts
+++ b/packages/cli/src/brownfield/commands/packageIos.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import path from 'node:path';
 
 import {
@@ -94,6 +95,17 @@ export const packageIosCommand = curryOptions(
       },
       platformConfig
     );
+
+    const reactBrownfieldXcframeworkPath = path.join(
+      packageDir,
+      'ReactBrownfield.xcframework'
+    );
+    if (fs.existsSync(reactBrownfieldXcframeworkPath)) {
+      // Strip the binary from ReactBrownfield.xcframework to make it interface-only.
+      // This avoids duplicate symbols when consumer apps embed both BrownfieldLib
+      // (which contains ReactBrownfield symbols) and ReactBrownfield.xcframework.
+      stripFrameworkBinary(reactBrownfieldXcframeworkPath);
+    }
 
     if (hasBrownie) {
       const productsPath = path.join(options.buildFolder, 'Build', 'Products');


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

Fixes - https://github.com/callstackincubator/rock/issues/636

**Problem**
Consumer apps link `BrownfieldLib` (which, via CocoaPods / `inherit! :complete`, already includes `ReactBrownfield` in the same framework binary) and ship `ReactBrownfield.xcframework` for import `ReactBrownfield` and Xcode integration. That loads two copies of the same Swift/ObjC types into the process, which surfaces as duplicate Objective‑C class registration and related duplicate-symbol issues.

**Solution**
After `packageIosAction` completes, if `ReactBrownfield.xcframework` exists under the package output directory, we run the same `stripFrameworkBinary` step already used for `Brownie.xcframework` and `BrownfieldNavigation.xcframework`. The `xcframework` stays usable for imports and Swift interfaces, while its Mach-O is replaced with a stub so implementations are not duplicated in apps that embed both `BrownfieldLib` and `ReactBrownfield.xcframework`.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

<details>

<summary>Before</summary>

https://github.com/user-attachments/assets/234c4cfc-b32f-451f-b14c-4496026b0d53




</details>


<details>

<summary>After</summary>

https://github.com/user-attachments/assets/4d58d0dc-7c66-4737-a6fd-dd79186f6a53




</details>
