### PR TITLE
docs: initial props demo docs & demos

### DIFF
--- a/apps/AndroidApp/app/src/main/java/com/callstack/brownfield/android/example/MainActivity.kt
+++ b/apps/AndroidApp/app/src/main/java/com/callstack/brownfield/android/example/MainActivity.kt
@@ -2,6 +2,7 @@ package com.callstack.brownfield.android.example
 
 import android.content.Intent
 import android.content.res.Configuration
+import android.os.Build
 import android.os.Bundle
 import android.widget.Toast
 import androidx.activity.compose.setContent
@@ -128,6 +129,15 @@ fun ReactNativeView(
             putString(
                 ReactNativeFragmentArgNames.ARG_MODULE_NAME,
                 ReactNativeConstants.MAIN_MODULE_NAME
+            )
+            putBundle(
+                ReactNativeFragmentArgNames.ARG_LAUNCH_OPTIONS,
+                Bundle().apply {
+                    putString(
+                        "nativeOsVersionLabel",
+                        "Android ${Build.VERSION.RELEASE}"
+                    )
+                }
             )
         }
     )

--- a/apps/AppleApp/Brownfield Apple App/components/ContentView.swift
+++ b/apps/AppleApp/Brownfield Apple App/components/ContentView.swift
@@ -23,7 +23,13 @@ struct ContentView: View {
 
                 MessagesView()
 
-                ReactNativeView(moduleName: "main")
+                ReactNativeView(
+                    moduleName: "main",
+                    initialProperties: [
+                        "nativeOsVersionLabel":
+                            "\(UIDevice.current.systemName) \(UIDevice.current.systemVersion)"
+                    ]
+                )
                     .navigationBarHidden(true)
                     .clipShape(RoundedRectangle(cornerRadius: 16))
                     .background(Color(UIColor.systemBackground))

--- a/apps/ExpoApp54/RNApp.tsx
+++ b/apps/ExpoApp54/RNApp.tsx
@@ -4,10 +4,23 @@ import BrownfieldNavigation from '@callstack/brownfield-navigation';
 
 import Counter from './components/counter';
 
-export default function RNApp() {
+type RNAppProps = {
+  nativeOsVersionLabel?: string;
+};
+
+export default function RNApp({ nativeOsVersionLabel }: RNAppProps) {
   return (
     <SafeAreaView style={styles.container}>
       <Text style={styles.title}>Expo React Native Brownfield</Text>
+
+      {nativeOsVersionLabel ? (
+        <Text
+          style={styles.nativeOsVersionLabel}
+          accessibilityLabel="Native OS version"
+        >
+          {nativeOsVersionLabel}
+        </Text>
+      ) : null}
 
       <View style={styles.content}>
         <Counter />
@@ -35,6 +48,12 @@ const styles = StyleSheet.create({
     fontSize: 20,
     fontWeight: 'bold',
     textAlign: 'center',
+  },
+  nativeOsVersionLabel: {
+    fontSize: 11,
+    opacity: 0.75,
+    textAlign: 'center',
+    marginTop: 4,
   },
   content: {
     flex: 1,

--- a/apps/ExpoApp55/RNApp.tsx
+++ b/apps/ExpoApp55/RNApp.tsx
@@ -4,10 +4,23 @@ import BrownfieldNavigation from '@callstack/brownfield-navigation';
 
 import Counter from './src/components/counter';
 
-export default function RNApp() {
+type RNAppProps = {
+  nativeOsVersionLabel?: string;
+};
+
+export default function RNApp({ nativeOsVersionLabel }: RNAppProps) {
   return (
     <SafeAreaView style={styles.container}>
       <Text style={styles.title}>Expo React Native Brownfield</Text>
+
+      {nativeOsVersionLabel ? (
+        <Text
+          style={styles.nativeOsVersionLabel}
+          accessibilityLabel="Native OS version"
+        >
+          {nativeOsVersionLabel}
+        </Text>
+      ) : null}
 
       <View style={styles.content}>
         <Counter />
@@ -35,6 +48,12 @@ const styles = StyleSheet.create({
     fontSize: 20,
     fontWeight: 'bold',
     textAlign: 'center',
+  },
+  nativeOsVersionLabel: {
+    fontSize: 11,
+    opacity: 0.75,
+    textAlign: 'center',
+    marginTop: 4,
   },
   content: {
     flex: 1,

--- a/apps/RNApp/src/App.tsx
+++ b/apps/RNApp/src/App.tsx
@@ -2,15 +2,22 @@ import '../BrownfieldStore.brownie';
 
 import { NavigationContainer } from '@react-navigation/native';
 
-import { Stack } from './navigation/RootStack';
 import { HomeScreen } from './HomeScreen';
+import { NativeOsVersionLabelContext } from './nativeHostContext';
+import { Stack } from './navigation/RootStack';
 
-export default function App() {
+type AppProps = {
+  nativeOsVersionLabel?: string;
+};
+
+export default function App({ nativeOsVersionLabel }: AppProps) {
   return (
-    <NavigationContainer>
-      <Stack.Navigator>
-        <Stack.Screen name="Home" component={HomeScreen} />
-      </Stack.Navigator>
-    </NavigationContainer>
+    <NativeOsVersionLabelContext.Provider value={nativeOsVersionLabel}>
+      <NavigationContainer>
+        <Stack.Navigator>
+          <Stack.Screen name="Home" component={HomeScreen} />
+        </Stack.Navigator>
+      </NavigationContainer>
+    </NativeOsVersionLabelContext.Provider>
   );
 }

--- a/apps/RNApp/src/HomeScreen.tsx
+++ b/apps/RNApp/src/HomeScreen.tsx
@@ -15,6 +15,7 @@ import BrownfieldNavigation from '@callstack/brownfield-navigation';
 import { getRandomTheme } from './utils';
 import type { RootStackParamList } from './navigation/RootStack';
 import Counter from './components/counter';
+import { useNativeOsVersionLabel } from './nativeHostContext';
 
 interface Message {
   id: string;
@@ -71,6 +72,7 @@ export function HomeScreen({
   navigation,
   route,
 }: NativeStackScreenProps<RootStackParamList, 'Home'>) {
+  const nativeOsVersionLabel = useNativeOsVersionLabel();
   const colors = route.params?.theme ? route.params.theme : getRandomTheme();
   const [messages, setMessages] = useState<Message[]>([]);
   const flatListRef = useRef<FlatList<Message>>(null);
@@ -121,6 +123,15 @@ export function HomeScreen({
       <Text style={[styles.text, { color: colors.secondary }]}>
         React Native Screen
       </Text>
+
+      {nativeOsVersionLabel ? (
+        <Text
+          style={[styles.nativeOsVersionLabel, { color: colors.secondary }]}
+          accessibilityLabel="Native OS version"
+        >
+          {nativeOsVersionLabel}
+        </Text>
+      ) : null}
 
       <Counter colors={colors} />
 
@@ -198,6 +209,12 @@ const styles = StyleSheet.create({
     fontSize: 26,
     fontWeight: 'bold',
     marginBottom: 8,
+  },
+  nativeOsVersionLabel: {
+    fontSize: 11,
+    opacity: 0.85,
+    marginBottom: 4,
+    textAlign: 'center',
   },
   messageSection: {
     flex: 1,

--- a/apps/RNApp/src/nativeHostContext.tsx
+++ b/apps/RNApp/src/nativeHostContext.tsx
@@ -1,0 +1,9 @@
+import { createContext, useContext } from 'react';
+
+export const NativeOsVersionLabelContext = createContext<string | undefined>(
+  undefined
+);
+
+export function useNativeOsVersionLabel(): string | undefined {
+  return useContext(NativeOsVersionLabelContext);
+}

--- a/docs/docs/docs/api-reference/react-native-brownfield/java.mdx
+++ b/docs/docs/docs/api-reference/react-native-brownfield/java.mdx
@@ -170,7 +170,7 @@ Creates a React Native view with a given module name. It automatically uses an i
 
 Returns: `FrameLayout` - A view containing the React Native component.
 
-Root initial props can be passed through the `launchOptions` argument of `createView`. That `Bundle` is forwarded as the root view's initial properties - the same concept as [initial props on `ReactRootView`](https://reactnative.dev/docs/communication-android#passing-properties-from-native-to-react-native).
+Root initial props can be passed through the `launchOptions` argument. That `Bundle` is forwarded as the root view's initial properties - the same concept as [initial props on `ReactRootView`](https://reactnative.dev/docs/communication-android#passing-properties-from-native-to-react-native).
 
 **Examples:**
 

--- a/docs/docs/docs/api-reference/react-native-brownfield/java.mdx
+++ b/docs/docs/docs/api-reference/react-native-brownfield/java.mdx
@@ -64,7 +64,10 @@ A function used to initialize a React Native Brownfield singleton. Keep in mind 
 
 > `*` - From the marked fields, exactly one must be specified, excluding the others. See examples below.
 
-**Available options:**
+> [!Note]
+> The `options` map for `initialize` is unrelated to the initial props passed to the root component. For passing in initial props, use the [`launchOptions` argument of `createView`](#createview).
+
+**Available `options` entries:**
 
 - `useDeveloperSupport`: `Boolean` - Flag to use dev support.
 - `packages`: `List<ReactPackage>` - List of your React Native Native modules.
@@ -166,6 +169,8 @@ Creates a React Native view with a given module name. It automatically uses an i
 | reactDelegate | No       | `ReactDelegateWrapper` | Optional custom delegate. If passed, the `activity` argument is ignored.                                                                         |
 
 Returns: `FrameLayout` - A view containing the React Native component.
+
+Root initial props can be passed through the `launchOptions` argument of `createView`. That `Bundle` is forwarded as the root view's initial properties - the same concept as [initial props on `ReactRootView`](https://reactnative.dev/docs/communication-android#passing-properties-from-native-to-react-native).
 
 **Examples:**
 

--- a/docs/docs/docs/api-reference/react-native-brownfield/kotlin.mdx
+++ b/docs/docs/docs/api-reference/react-native-brownfield/kotlin.mdx
@@ -47,7 +47,10 @@ A function used to initialize a React Native Brownfield singleton. Keep in mind 
 
 > `*` - From the marked fields, exactly one must be specified, excluding the others. See examples below.
 
-**Available options:**
+> [!Note]
+> The `options` map for `initialize` is unrelated to the initial props passed to the root component. For passing in initial props, use the [`launchOptions` argument of `createView`](#createview).
+
+**Available `options` entries:**
 
 - `useDeveloperSupport`: `Boolean` - Flag to use dev support.
 - `packages`: `List<ReactPackage>` - List of your React Native Native modules.
@@ -145,6 +148,8 @@ Creates a React Native view with a given module name. It automatically uses an i
 | reactDelegate | No       | `ReactDelegateWrapper` | Optional custom delegate. If passed, the `activity` argument is ignored.                                                                       |
 
 Returns: `FrameLayout` - A view containing the React Native component.
+
+Root initial props can be passed through the `launchOptions` argument of `createView`. That `Bundle` is forwarded as the root view's initial properties - the same concept as [initial props on `ReactRootView`](https://reactnative.dev/docs/communication-android#passing-properties-from-native-to-react-native).
 
 **Examples:**
 

--- a/docs/docs/docs/api-reference/react-native-brownfield/kotlin.mdx
+++ b/docs/docs/docs/api-reference/react-native-brownfield/kotlin.mdx
@@ -149,7 +149,7 @@ Creates a React Native view with a given module name. It automatically uses an i
 
 Returns: `FrameLayout` - A view containing the React Native component.
 
-Root initial props can be passed through the `launchOptions` argument of `createView`. That `Bundle` is forwarded as the root view's initial properties - the same concept as [initial props on `ReactRootView`](https://reactnative.dev/docs/communication-android#passing-properties-from-native-to-react-native).
+Root initial props can be passed through the `launchOptions` argument. That `Bundle` is forwarded as the root view's initial properties - the same concept as [initial props on `ReactRootView`](https://reactnative.dev/docs/communication-android#passing-properties-from-native-to-react-native).
 
 **Examples:**
 

--- a/docs/docs/docs/api-reference/react-native-brownfield/objective-c.mdx
+++ b/docs/docs/docs/api-reference/react-native-brownfield/objective-c.mdx
@@ -47,8 +47,6 @@ Starts React Native, produces an instance of React Native. You can use it to ini
 | ---------------- | -------- | --------------- | ------------------------------------------------- |
 | `onBundleLoaded` | No       | `void(^)(void)` | Callback invoked after JS bundle is fully loaded. |
 
-Root initial props can be passed through the `initialProps` argument of `createView`. That `NSDictionary` is forwarded as the root view's initial properties - the same concept as [initial props on `ReactRootView`](https://reactnative.dev/docs/communication-android#passing-properties-from-native-to-react-native).
-
 **Examples:**
 
 ```objc
@@ -70,6 +68,8 @@ Creates a React Native view for the specified module name.
 | `moduleName`    | Yes      | `NSString`     | Name of React Native component registered to `AppRegistry`. |
 | `initialProps`  | No       | `NSDictionary` | Initial properties to be passed to React Native component.  |
 | `launchOptions` | No       | `NSDictionary` | Launch options, typically passed from AppDelegate.          |
+
+Root initial props can be passed through the `initialProps` argument. That `NSDictionary` is forwarded as the root view's initial properties - the same concept as [initial props on `RCTRootView`](https://reactnative.dev/docs/communication-ios#passing-properties-from-native-to-react-native).
 
 **Examples:**
 

--- a/docs/docs/docs/api-reference/react-native-brownfield/objective-c.mdx
+++ b/docs/docs/docs/api-reference/react-native-brownfield/objective-c.mdx
@@ -47,6 +47,8 @@ Starts React Native, produces an instance of React Native. You can use it to ini
 | ---------------- | -------- | --------------- | ------------------------------------------------- |
 | `onBundleLoaded` | No       | `void(^)(void)` | Callback invoked after JS bundle is fully loaded. |
 
+Root initial props can be passed through the `initialProps` argument of `createView`. That `NSDictionary` is forwarded as the root view's initial properties - the same concept as [initial props on `ReactRootView`](https://reactnative.dev/docs/communication-android#passing-properties-from-native-to-react-native).
+
 **Examples:**
 
 ```objc

--- a/docs/docs/docs/api-reference/react-native-brownfield/swift.mdx
+++ b/docs/docs/docs/api-reference/react-native-brownfield/swift.mdx
@@ -47,6 +47,8 @@ Starts React Native. You can use it to initialize React Native in your app.
 | ---------------- | -------- | --------------- | ------------------------------------------------- |
 | `onBundleLoaded` | No       | `(() -> Void)?` | Callback invoked after JS bundle is fully loaded. |
 
+Root initial props can be passed through the `initialProps` argument of `view`. That `[AnyHashable: Any]?` is forwarded as the root view's initial properties - the same concept as [initial props on `ReactRootView`](https://reactnative.dev/docs/communication-android#passing-properties-from-native-to-react-native).
+
 **Examples:**
 
 ```swift

--- a/docs/docs/docs/api-reference/react-native-brownfield/swift.mdx
+++ b/docs/docs/docs/api-reference/react-native-brownfield/swift.mdx
@@ -47,8 +47,6 @@ Starts React Native. You can use it to initialize React Native in your app.
 | ---------------- | -------- | --------------- | ------------------------------------------------- |
 | `onBundleLoaded` | No       | `(() -> Void)?` | Callback invoked after JS bundle is fully loaded. |
 
-Root initial props can be passed through the `initialProps` argument of `view`. That `[AnyHashable: Any]?` is forwarded as the root view's initial properties - the same concept as [initial props on `ReactRootView`](https://reactnative.dev/docs/communication-android#passing-properties-from-native-to-react-native).
-
 **Examples:**
 
 ```swift
@@ -70,6 +68,8 @@ Creates a React Native view for the specified module name.
 | `moduleName`    | Yes      | `String`              | Name of React Native component registered to `AppRegistry`. |
 | `initialProps`  | No       | `[AnyHashable: Any]?` | Initial properties to be passed to React Native component.  |
 | `launchOptions` | No       | `[AnyHashable: Any]?` | Launch options, typically passed from AppDelegate.          |
+
+Root initial props can be passed through the `initialProps` argument. That `[AnyHashable: Any]?` is forwarded as the root view's initial properties - the same concept as [initial props on `RCTRootView`](https://reactnative.dev/docs/communication-ios#passing-properties-from-native-to-react-native).
 
 **Examples:**
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
This PR adds 2 enhancements:
- updates docs to disambiguate the options exposed by our public API for passing in initial root component props to a brownfield RN view, which apparently cause confusion (e.g. #130)
- updates the demo apps to receive a demo props being the OS version string from the native side, and display it to the user

<img width="346" height="710" alt="image" src="https://github.com/user-attachments/assets/2b3c8ba7-3cde-435a-becc-6a7d8049a29e" />

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
CI green + tested manually.