### PR TITLE
fix: support 16KB page sizes in Brownie

### DIFF
--- a/.changeset/chubby-grapes-jog.md
+++ b/.changeset/chubby-grapes-jog.md
@@ -1,0 +1,5 @@
+---
+'@callstack/brownie': patch
+---
+
+fix: build Brownie Android with support for 16KB page sizes

--- a/packages/brownie/android/build.gradle
+++ b/packages/brownie/android/build.gradle
@@ -45,7 +45,7 @@ android {
 
     externalNativeBuild {
       cmake {
-        arguments "-DANDROID_STL=c++_shared -DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
+        arguments "-DANDROID_STL=c++_shared", "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
         cppFlags "-std=c++20 -fexceptions -frtti"
       }
     }

--- a/packages/brownie/android/build.gradle
+++ b/packages/brownie/android/build.gradle
@@ -45,7 +45,7 @@ android {
 
     externalNativeBuild {
       cmake {
-        arguments "-DANDROID_STL=c++_shared"
+        arguments "-DANDROID_STL=c++_shared -DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
         cppFlags "-std=c++20 -fexceptions -frtti"
       }
     }


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
Build Brownie Android with [support for 16KB page sizes](https://developer.android.com/guide/practices/page-sizes#kotlin_1).

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
CI green.