### PR TITLE
fix: make sure native libs are loaded for RN >= 0.80

### DIFF
--- a/.changeset/early-rice-fly.md
+++ b/.changeset/early-rice-fly.md
@@ -1,0 +1,5 @@
+---
+'@callstack/react-native-brownfield': patch
+---
+
+fix: make sure native libs are loaded for RN >= 0.80

--- a/apps/RNApp/android/BrownfieldLib/consumer-rules.pro
+++ b/apps/RNApp/android/BrownfieldLib/consumer-rules.pro
@@ -1,1 +1,0 @@
--keep class com.facebook.react.ReactNativeApplicationEntryPoint { *; }

--- a/apps/RNApp/android/BrownfieldLib/consumer-rules.pro
+++ b/apps/RNApp/android/BrownfieldLib/consumer-rules.pro
@@ -1,0 +1,1 @@
+-keep class com.facebook.react.ReactNativeApplicationEntryPoint { *; }

--- a/apps/RNApp/android/BrownfieldLib/src/main/java/com/rnapp/brownfieldlib/ReactNativeHostManager.kt
+++ b/apps/RNApp/android/BrownfieldLib/src/main/java/com/rnapp/brownfieldlib/ReactNativeHostManager.kt
@@ -4,12 +4,9 @@ import android.app.Application
 import com.callstack.reactnativebrownfield.OnJSBundleLoaded
 import com.callstack.reactnativebrownfield.ReactNativeBrownfield
 import com.facebook.react.PackageList
-import com.facebook.react.ReactNativeApplicationEntryPoint.loadReactNative
 
 object ReactNativeHostManager {
     fun initialize(application: Application, onJSBundleLoaded: OnJSBundleLoaded? = null) {
-        loadReactNative(application)
-
         val packageList = PackageList(application).packages
         ReactNativeBrownfield.initialize(application, packageList, onJSBundleLoaded)
     }

--- a/packages/react-native-brownfield/android/src/main/java/com/callstack/reactnativebrownfield/ReactNativeBrownfield.kt
+++ b/packages/react-native-brownfield/android/src/main/java/com/callstack/reactnativebrownfield/ReactNativeBrownfield.kt
@@ -72,7 +72,7 @@ class ReactNativeBrownfield private constructor(val reactHost: ReactHost) {
                     throw RuntimeException(
                         "ReactNativeApplicationEntryPoint not found. Ensure the brownfield AAR " +
                         "consumer-rules.pro is applied and ReactNativeApplicationEntryPoint is " +
-                        "not stripped by R8."
+                        "not stripped by R8.",
                         e
                     )
                 }

--- a/packages/react-native-brownfield/android/src/main/java/com/callstack/reactnativebrownfield/ReactNativeBrownfield.kt
+++ b/packages/react-native-brownfield/android/src/main/java/com/callstack/reactnativebrownfield/ReactNativeBrownfield.kt
@@ -41,17 +41,41 @@ class ReactNativeBrownfield private constructor(val reactHost: ReactHost) {
     companion object {
         private lateinit var instance: ReactNativeBrownfield
         private val initialized = AtomicBoolean()
+        private val nativeLibsLoaded = AtomicBoolean()
         private const val LOG_TAG = "ReactNativeBrownfield"
 
         @JvmStatic
         val shared: ReactNativeBrownfield get() = instance
 
         private fun loadNativeLibs(application: Application) {
+            if (!nativeLibsLoaded.getAndSet(true)) {
+                loadNativeLibsInternal(application)
+            }
+        }
+
+        private fun loadNativeLibsInternal(application: Application) {
             val rnVersion = BuildConfig.RN_VERSION
 
             if (VersionUtils.isVersionLessThan(rnVersion, RN_THRESHOLD_VERSION)) {
                 SoLoader.init(application.applicationContext, OpenSourceMergedSoMapping)
                 load()
+            } else {
+                try {
+                    val reactNativeApplicationEntryPointClazz =
+                        Class.forName("com.facebook.react.ReactNativeApplicationEntryPoint")
+                    val loadReactNativeMethod = reactNativeApplicationEntryPointClazz.getMethod(
+                        "loadReactNative",
+                        android.content.Context::class.java
+                    )
+                    loadReactNativeMethod.invoke(null, application.applicationContext)
+                } catch (e: ClassNotFoundException) {
+                    throw RuntimeException(
+                        "ReactNativeApplicationEntryPoint not found. Ensure the brownfield AAR " +
+                        "consumer-rules.pro is applied and ReactNativeApplicationEntryPoint is " +
+                        "not stripped by R8."
+                        e
+                    )
+                }
             }
         }
 
@@ -79,6 +103,8 @@ class ReactNativeBrownfield private constructor(val reactHost: ReactHost) {
             options: HashMap<String, Any>,
             onJSBundleLoaded: OnJSBundleLoaded? = null
         ) {
+            loadNativeLibs(application)
+
             val reactHost: ReactHost by lazy {
                 getDefaultReactHost(
                     context = application,

--- a/packages/react-native-brownfield/android/src/main/java/com/callstack/reactnativebrownfield/ReactNativeBrownfield.kt
+++ b/packages/react-native-brownfield/android/src/main/java/com/callstack/reactnativebrownfield/ReactNativeBrownfield.kt
@@ -7,7 +7,6 @@ import androidx.activity.OnBackPressedCallback
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
-import com.callstack.reactnativebrownfield.utils.VersionUtils
 import com.facebook.react.ReactHost
 import com.facebook.react.ReactInstanceEventListener
 import com.facebook.react.ReactPackage
@@ -28,13 +27,6 @@ fun interface OnMessageListener {
     fun onMessage(message: String)
 }
 
-/**
- * The threshold RN version based on which we decide whether to
- * load JNI libs or not. We only load JNI libs on version less
- * than this.
- */
-private const val RN_THRESHOLD_VERSION = "0.80.0"
-
 class ReactNativeBrownfield private constructor(val reactHost: ReactHost) {
     private val messageListeners = CopyOnWriteArrayList<OnMessageListener>()
 
@@ -54,29 +46,8 @@ class ReactNativeBrownfield private constructor(val reactHost: ReactHost) {
         }
 
         private fun loadNativeLibsInternal(application: Application) {
-            val rnVersion = BuildConfig.RN_VERSION
-
-            if (VersionUtils.isVersionLessThan(rnVersion, RN_THRESHOLD_VERSION)) {
-                SoLoader.init(application.applicationContext, OpenSourceMergedSoMapping)
-                load()
-            } else {
-                try {
-                    val reactNativeApplicationEntryPointClazz =
-                        Class.forName("com.facebook.react.ReactNativeApplicationEntryPoint")
-                    val loadReactNativeMethod = reactNativeApplicationEntryPointClazz.getMethod(
-                        "loadReactNative",
-                        android.content.Context::class.java
-                    )
-                    loadReactNativeMethod.invoke(null, application.applicationContext)
-                } catch (e: ClassNotFoundException) {
-                    throw RuntimeException(
-                        "ReactNativeApplicationEntryPoint not found. Ensure the brownfield AAR " +
-                        "consumer-rules.pro is applied and ReactNativeApplicationEntryPoint is " +
-                        "not stripped by R8.",
-                        e
-                    )
-                }
-            }
+            SoLoader.init(application.applicationContext, OpenSourceMergedSoMapping)
+            load()
         }
 
         @JvmStatic

--- a/packages/react-native-brownfield/src/expo-config-plugin/template/android/ReactNativeHostManager.post55.kt
+++ b/packages/react-native-brownfield/src/expo-config-plugin/template/android/ReactNativeHostManager.post55.kt
@@ -6,14 +6,11 @@ import com.callstack.reactnativebrownfield.OnJSBundleLoaded
 import com.callstack.reactnativebrownfield.ReactNativeBrownfield
 import com.facebook.react.PackageList
 import com.facebook.react.ReactHost
-import com.facebook.react.ReactNativeApplicationEntryPoint.loadReactNative
 import expo.modules.ApplicationLifecycleDispatcher
 import expo.modules.ExpoReactHostFactory
 
 object ReactNativeHostManager {
     fun initialize(application: Application, onJSBundleLoaded: OnJSBundleLoaded? = null) {
-        loadReactNative(application)
-
         ApplicationLifecycleDispatcher.onApplicationCreate(application)
 
         val reactHost: ReactHost by lazy {

--- a/packages/react-native-brownfield/src/expo-config-plugin/template/android/ReactNativeHostManager.pre55.kt
+++ b/packages/react-native-brownfield/src/expo-config-plugin/template/android/ReactNativeHostManager.pre55.kt
@@ -6,7 +6,6 @@ import com.callstack.reactnativebrownfield.OnJSBundleLoaded
 import com.callstack.reactnativebrownfield.ReactNativeBrownfield
 import com.facebook.react.PackageList
 import com.facebook.react.ReactHost
-import com.facebook.react.ReactNativeApplicationEntryPoint.loadReactNative
 import com.facebook.react.ReactPackage
 import com.facebook.react.defaults.DefaultReactNativeHost
 import expo.modules.ApplicationLifecycleDispatcher
@@ -15,8 +14,6 @@ import expo.modules.ReactNativeHostWrapper
 
 object ReactNativeHostManager {
     fun initialize(application: Application, onJSBundleLoaded: OnJSBundleLoaded? = null) {
-        loadReactNative(application)
-
         ApplicationLifecycleDispatcher.onApplicationCreate(application)
 
         val reactNativeHost = ReactNativeHostWrapper(


### PR DESCRIPTION
### Summary

`loadNativeLibs()` in `ReactNativeBrownfield.kt` is a no-op for `RN >= 0.80`. All `ReactNativeHostManager` templates call `loadReactNative(application)` BEFORE `ReactNativeBrownfield.initialize()`, so when done through the recommended path the libs load. But `loadNativeLibs()` — called inside every `initialize()` overload — silently skips for `RN >= 0.80`. Any consumer using `ReactNativeBrownfield.initialize()` directly — with a custom `ReactHost`, custom packages list, or custom options — skipped native lib loading entirely. Without `JNI_OnLoad` firing, `registerComponentDescriptorsFromEntryPoint` and the `DefaultTurboModuleManagerDelegate` module providers were never assigned, leading to the `SIGSEGV` during _Fabric_ initialization.

`ddc011c` — moved `SoLoader.init()` from `preloadReactNative()` into `initialize(application, rnHost, ...)`. Before this, `SoLoader.init()` was called inside `preloadReactNative` after creating the _React_ context. It was consolidated into the initialize entry point.
`9908b68` — added the `RN_THRESHOLD_VERSION = "0.80.0"` gate and removed `SoLoader.init()` + `load()` for `RN ≥ 0.80`, leaving those calls only for `< 0.80`.

`ReactNativeBrownfield.initialize()` itself had no fallback for the `RN ≥ 0.80` case. If anything bypasses `ReactNativeHostManager` — a custom `ReactHost`, a consumer calling `initialize()` directly, or the generated `ReactNativeApplicationEntryPoint` being unavailable — native libs are never loaded. That's the bug this fix addresses.

### Test plan

To genuinely reproduce the original crash we'd need one of:
* the version of the AAR from before `59f472b` consumed by the reporter's enterprise app
* an APK that deliberately ships two conflicting versions of `libreact_codegen_rnscreens.so`

Neither is practical to set up cleanly. The _`SoLoader.init()` not yet called_ crash the GH issue reporter produced is sufficient proof that the same class of bug exists — the fix prevents both the Java exception AND the conditions that led to the original native crash.

---

Closes #283