### PR TITLE
feat: strip SO files by default, deprecate experimental option in favor of useStrippedSoFiles

### DIFF
--- a/.changeset/frank-chairs-grin.md
+++ b/.changeset/frank-chairs-grin.md
@@ -1,0 +1,7 @@
+---
+'brownfield': minor
+'@callstack/brownfield-cli': minor
+'@callstack/react-native-brownfield': minor
+---
+
+feat: strip SO files by default, deprecate experimental option in favor of useStrippedSoFiles

--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/processors/JNILibsProcessor.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/processors/JNILibsProcessor.kt
@@ -53,7 +53,7 @@ class JNILibsProcessor : BaseProject() {
                 for (archiveLibrary in aarLibraries) {
                     val jniDir = archiveLibrary.getJniDir()
                     processNestedLibs(jniDir.listFiles(), existingJNILibs)
-                    if (projectExt.experimentalUseStrippedSoFiles) {
+                    if (projectExt.useStrippedSoFiles) {
                         copyStrippedSoLibs(variant, existingJNILibs)
                     } else {
                         if (jniDir.exists()) {

--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/utils/Extension.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/utils/Extension.kt
@@ -34,7 +34,7 @@ open class Extension {
      * List of dynamic libs (.so) files that you wish to bundle with
      * the aar.
      *
-     * By default only `libappmodules.so` and `libreact_codegen_*.so` are
+     * By default, only `libappmodules.so` and `libreact_codegen_*.so` are
      * bundled.
      */
     var dynamicLibs = listOf<String>()
@@ -42,7 +42,18 @@ open class Extension {
     /**
      * Whether to use stripped .so files.
      *
-     * Default value is `false`
+     * Default is `true`.
      */
-    var experimentalUseStrippedSoFiles = false
+    var useStrippedSoFiles = true
+
+    @Deprecated(
+        message = "This property is deprecated and will be removed in a future release. The successor is useStrippedSoFiles, which is by default true.",
+        replaceWith = ReplaceWith("useStrippedSoFiles"),
+        level = DeprecationLevel.WARNING
+    )
+    var experimentalUseStrippedSoFiles
+        get() = useStrippedSoFiles
+        set(value) {
+            useStrippedSoFiles = value
+        }
 }

--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/utils/Extension.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/utils/Extension.kt
@@ -47,9 +47,11 @@ open class Extension {
     var useStrippedSoFiles = true
 
     @Deprecated(
-        message = "This property is deprecated and will be removed in a future release. The successor is useStrippedSoFiles, which is by default true.",
+        message =
+            "This property is deprecated and will be removed in a future release." +
+                "The successor is useStrippedSoFiles, which is by default true.",
         replaceWith = ReplaceWith("useStrippedSoFiles"),
-        level = DeprecationLevel.WARNING
+        level = DeprecationLevel.WARNING,
     )
     var experimentalUseStrippedSoFiles
         get() = useStrippedSoFiles

--- a/gradle-plugins/react/example-android-library/build.gradle.kts
+++ b/gradle-plugins/react/example-android-library/build.gradle.kts
@@ -1,4 +1,3 @@
-
 plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")


### PR DESCRIPTION
### Summary

This PR:
- deprecates `experimentalUseStrippedSoFiles` in favor of `useStrippedSoFiles`
- `useStrippedSoFiles` is `true` by default (`experimentalUseStrippedSoFiles` used to be `false` by default)

### Test plan

CI green.
