### PR TITLE
chore(ci): optimize CI only to be invoked on path changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
       expo55: ${{ steps.filter.outputs.expo55 }}
       androidapp: ${{ steps.filter.outputs.androidapp }}
       appleapp: ${{ steps.filter.outputs.appleapp }}
+      ci: ${{ steps.filter.outputs.ci }}
     steps:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
@@ -42,6 +43,8 @@ jobs:
               - 'apps/AndroidApp/**'
             appleapp:
               - 'apps/AppleApp/**'
+            ci:
+              - '.github/**'
 
   check-changeset:
     name: Check changeset
@@ -65,7 +68,7 @@ jobs:
     name: Build, lint, typecheck & Jest
     runs-on: ubuntu-latest
     needs: filter
-    if: needs.filter.outputs.packages == 'true'
+    if: needs.filter.outputs.packages == 'true' || needs.filter.outputs.ci == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
@@ -99,7 +102,8 @@ jobs:
         needs.filter.outputs.expo54 == 'true' ||
         needs.filter.outputs.expo55 == 'true' ||
         needs.filter.outputs.androidapp == 'true' ||
-        needs.filter.outputs.packages == 'true'
+        needs.filter.outputs.packages == 'true' ||
+        needs.filter.outputs.ci == 'true'
       ) &&
       (needs.build-lint.result == 'success' || needs.build-lint.result == 'skipped')
     strategy:
@@ -128,7 +132,8 @@ jobs:
       (
         needs.filter.outputs.rnapp == 'true' ||
         needs.filter.outputs.androidapp == 'true' ||
-        needs.filter.outputs.packages == 'true'
+        needs.filter.outputs.packages == 'true' ||
+        needs.filter.outputs.ci == 'true'
       ) &&
       (needs.build-lint.result == 'success' || needs.build-lint.result == 'skipped')
 
@@ -152,7 +157,8 @@ jobs:
       (
         needs.filter.outputs.rnapp == 'true' ||
         needs.filter.outputs.appleapp == 'true' ||
-        needs.filter.outputs.packages == 'true'
+        needs.filter.outputs.packages == 'true' ||
+        needs.filter.outputs.ci == 'true'
       ) &&
       (needs.build-lint.result == 'success' || needs.build-lint.result == 'skipped')
 
@@ -176,7 +182,8 @@ jobs:
         needs.filter.outputs.expo54 == 'true' ||
         needs.filter.outputs.expo55 == 'true' ||
         needs.filter.outputs.appleapp == 'true' ||
-        needs.filter.outputs.packages == 'true'
+        needs.filter.outputs.packages == 'true' ||
+        needs.filter.outputs.ci == 'true'
       ) &&
       (needs.build-lint.result == 'success' || needs.build-lint.result == 'skipped')
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,43 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  filter:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      packages: ${{ steps.filter.outputs.packages }}
+      rnapp: ${{ steps.filter.outputs.rnapp }}
+      expo54: ${{ steps.filter.outputs.expo54 }}
+      expo55: ${{ steps.filter.outputs.expo55 }}
+      androidapp: ${{ steps.filter.outputs.androidapp }}
+      appleapp: ${{ steps.filter.outputs.appleapp }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+
+      - name: Filter paths
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            packages:
+              - 'packages/**'
+            rnapp:
+              - 'apps/RNApp/**'
+            expo54:
+              - 'apps/ExpoApp54/**'
+            expo55:
+              - 'apps/ExpoApp55/**'
+            androidapp:
+              - 'apps/AndroidApp/**'
+            appleapp:
+              - 'apps/AppleApp/**'
+
   check-changeset:
     name: Check changeset
     runs-on: ubuntu-latest
+    needs: filter
+    if: needs.filter.outputs.packages == 'true'
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
@@ -30,6 +64,8 @@ jobs:
   build-lint:
     name: Build, lint, typecheck & Jest
     runs-on: ubuntu-latest
+    needs: filter
+    if: needs.filter.outputs.packages == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
@@ -56,7 +92,16 @@ jobs:
   android-androidapp-expo:
     name: Android road test (RNApp & AndroidApp - Expo ${{ matrix.version }})
     runs-on: ubuntu-latest
-    needs: build-lint
+    needs: [filter, build-lint]
+    if: |
+      always() &&
+      (
+        needs.filter.outputs.expo54 == 'true' ||
+        needs.filter.outputs.expo55 == 'true' ||
+        needs.filter.outputs.androidapp == 'true' ||
+        needs.filter.outputs.packages == 'true'
+      ) &&
+      (needs.build-lint.result == 'success' || needs.build-lint.result == 'skipped')
     strategy:
       matrix:
         include:
@@ -77,7 +122,15 @@ jobs:
   android-androidapp-vanilla:
     name: Android road test (RNApp & AndroidApp - Vanilla)
     runs-on: ubuntu-latest
-    needs: build-lint
+    needs: [filter, build-lint]
+    if: |
+      always() &&
+      (
+        needs.filter.outputs.rnapp == 'true' ||
+        needs.filter.outputs.androidapp == 'true' ||
+        needs.filter.outputs.packages == 'true'
+      ) &&
+      (needs.build-lint.result == 'success' || needs.build-lint.result == 'skipped')
 
     steps:
       - name: Checkout
@@ -93,7 +146,15 @@ jobs:
   ios-appleapp-vanilla:
     name: iOS road test (RNApp & AppleApp - Vanilla)
     runs-on: macos-26
-    needs: build-lint
+    needs: [filter, build-lint]
+    if: |
+      always() &&
+      (
+        needs.filter.outputs.rnapp == 'true' ||
+        needs.filter.outputs.appleapp == 'true' ||
+        needs.filter.outputs.packages == 'true'
+      ) &&
+      (needs.build-lint.result == 'success' || needs.build-lint.result == 'skipped')
 
     steps:
       - name: Checkout
@@ -108,7 +169,16 @@ jobs:
   ios-appleapp-expo:
     name: iOS road test (RNApp & AppleApp - Expo ${{ matrix.version }})
     runs-on: macos-26
-    needs: build-lint
+    needs: [filter, build-lint]
+    if: |
+      always() &&
+      (
+        needs.filter.outputs.expo54 == 'true' ||
+        needs.filter.outputs.expo55 == 'true' ||
+        needs.filter.outputs.appleapp == 'true' ||
+        needs.filter.outputs.packages == 'true'
+      ) &&
+      (needs.build-lint.result == 'success' || needs.build-lint.result == 'skipped')
     strategy:
       matrix:
         include:


### PR DESCRIPTION
### Summary

|What to change|Expected jobs to run|
|-|-|
|README.md only|`filter` only|
|`packages/**`|`filter`, `check-changeset`, `build-lint`, all 4 road tests|
|`apps/RNApp/` only|`filter`, `android-androidapp-vanilla`, `ios-appleapp-vanilla`|
|`apps/ExpoApp54/` only|`filter`, `android-androidapp-expo`, `ios-appleapp-expo`|
|`apps/ExpoApp55/` only|`filter`, `android-androidapp-expo`, `ios-appleapp-expo`|
|`apps/AndroidApp/` only|`filter`, `android-androidapp-expo`, `android-androidapp-vanilla`|
|`apps/AppleApp/` only|`filter`, `ios-appleapp-vanilla`, `ios-appleapp-expo`|

### Test plan

dummy PRs with changes from each category:
- https://github.com/callstack/react-native-brownfield/pull/325
- https://github.com/callstack/react-native-brownfield/pull/327
- https://github.com/callstack/react-native-brownfield/pull/328
- https://github.com/callstack/react-native-brownfield/pull/329
- https://github.com/callstack/react-native-brownfield/pull/330
- https://github.com/callstack/react-native-brownfield/pull/331
- https://github.com/callstack/react-native-brownfield/pull/332
