### PR TITLE
fix: allow Object params to correctly reflect the native code gen

### DIFF
--- a/.changeset/bright-insects-pay.md
+++ b/.changeset/bright-insects-pay.md
@@ -1,0 +1,5 @@
+---
+'@callstack/brownfield-cli': patch
+---
+
+fix: Object params correctly reflect the generated native code instead of Any

--- a/apps/AndroidApp/app/src/main/java/com/callstack/brownfield/android/example/MainActivity.kt
+++ b/apps/AndroidApp/app/src/main/java/com/callstack/brownfield/android/example/MainActivity.kt
@@ -31,6 +31,7 @@ import com.callstack.brownfield.android.example.components.PostMessageCard
 import com.callstack.brownfield.android.example.ui.theme.AndroidBrownfieldAppTheme
 import com.callstack.nativebrownfieldnavigation.BrownfieldNavigationDelegate
 import com.callstack.nativebrownfieldnavigation.BrownfieldNavigationManager
+import com.callstack.nativebrownfieldnavigation.UserType
 import com.callstack.reactnativebrownfield.ReactNativeFragment
 import com.callstack.reactnativebrownfield.constants.ReactNativeFragmentArgNames
 
@@ -81,7 +82,7 @@ class MainActivity : AppCompatActivity(), BrownfieldNavigationDelegate {
         }
     }
 
-    override fun navigateToSettings() {
+    override fun navigateToSettings(user: UserType) {
         startActivity(Intent(this, SettingsActivity::class.java))
     }
 

--- a/apps/AppleApp/Brownfield Apple App/BrownfieldAppleApp.swift
+++ b/apps/AppleApp/Brownfield Apple App/BrownfieldAppleApp.swift
@@ -25,7 +25,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 }
 
 public class RNNavigationDelegate: BrownfieldNavigationDelegate {
-    public func navigateToSettings() {
+    public func navigateToSettings(_ user: BrownfieldNavigation.UserType) {
         present(SettingsScreen())
     }
 

--- a/apps/ExpoApp54/brownfield.navigation.ts
+++ b/apps/ExpoApp54/brownfield.navigation.ts
@@ -1,8 +1,14 @@
+type UserType = {
+  id: string;
+  name: string;
+  email: string;
+};
+
 export interface BrownfieldNavigationSpec {
   /**
    * Navigate to the native settings screen
    */
-  navigateToSettings(): void;
+  navigateToSettings(user: UserType): void;
 
   /**
    * Navigate to the native referrals screen

--- a/apps/ExpoApp54/brownfield.navigation.ts
+++ b/apps/ExpoApp54/brownfield.navigation.ts
@@ -1,7 +1,14 @@
 type UserType = {
   id: string;
   name: string;
-  email: string;
+  email?: string;
+  flags: string[];
+  ids: string[] | null;
+  avatar?: AvatarType;
+};
+
+type AvatarType = {
+  url: string;
 };
 
 export interface BrownfieldNavigationSpec {

--- a/apps/ExpoApp55/brownfield.navigation.ts
+++ b/apps/ExpoApp55/brownfield.navigation.ts
@@ -1,8 +1,14 @@
+type UserType = {
+  id: string;
+  name: string;
+  email: string;
+};
+
 export interface BrownfieldNavigationSpec {
   /**
    * Navigate to the native settings screen
    */
-  navigateToSettings(): void;
+  navigateToSettings(user: UserType): void;
 
   /**
    * Navigate to the native referrals screen

--- a/apps/ExpoApp55/brownfield.navigation.ts
+++ b/apps/ExpoApp55/brownfield.navigation.ts
@@ -1,7 +1,14 @@
 type UserType = {
   id: string;
   name: string;
-  email: string;
+  email?: string;
+  flags: string[];
+  ids: string[] | null;
+  avatar?: AvatarType;
+};
+
+type AvatarType = {
+  url: string;
 };
 
 export interface BrownfieldNavigationSpec {

--- a/apps/RNApp/brownfield.navigation.ts
+++ b/apps/RNApp/brownfield.navigation.ts
@@ -1,8 +1,14 @@
+type UserType = {
+  id: string;
+  name: string;
+  email: string;
+};
+
 export interface BrownfieldNavigationSpec {
   /**
    * Navigate to the native settings screen
    */
-  navigateToSettings(): void;
+  navigateToSettings(user: UserType): void;
 
   /**
    * Navigate to the native referrals screen

--- a/apps/RNApp/brownfield.navigation.ts
+++ b/apps/RNApp/brownfield.navigation.ts
@@ -1,7 +1,14 @@
 type UserType = {
   id: string;
   name: string;
-  email: string;
+  email?: string;
+  flags: string[];
+  ids: string[] | null;
+  avatar?: AvatarType;
+};
+
+type AvatarType = {
+  url: string;
 };
 
 export interface BrownfieldNavigationSpec {

--- a/apps/RNApp/ios/Podfile.lock
+++ b/apps/RNApp/ios/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - boost (1.84.0)
-  - BrownfieldNavigation (3.6.0):
+  - BrownfieldNavigation (3.7.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -28,7 +28,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - Brownie (3.6.0):
+  - Brownie (3.7.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2461,7 +2461,7 @@ PODS:
     - SocketRocket
   - ReactAppDependencyProvider (0.85.0):
     - ReactCodegen
-  - ReactBrownfield (3.6.0):
+  - ReactBrownfield (3.7.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2898,8 +2898,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
-  BrownfieldNavigation: 0a4abcd0295639640d0222ac5c47ab63d94983c8
-  Brownie: c75e781646955724c3b385e1a53704cc06491bf0
+  BrownfieldNavigation: 2a110b2734c33e3a695e28117ff4515c9bb0a035
+  Brownie: b30acefef59a97b9d84353b4e010af58f09dc900
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
   FBLazyVector: dfb9ab6ee2eac316f7869edf6ec27b9e872329f0
@@ -2974,7 +2974,7 @@ SPEC CHECKSUMS:
   React-utils: f2dc3878565c3cc54bdf7f65a106efaf93f189a6
   React-webperformancenativemodule: 214e42892a044b865f73ad4f88cac6979c27aa76
   ReactAppDependencyProvider: 5787b37b8e2e51dfeab697ec031cc7c4080dcea2
-  ReactBrownfield: 9e36bd174c53254c7a283a6305a4b26589e75f97
+  ReactBrownfield: 0420c061dccf3a41c495fd2fecc22a6faed5d7fd
   ReactCodegen: 6ddd8f44847646a047320a22f5ddb10b27a515c9
   ReactCommon: 6a42764f1136fb9ac210e05e88a0733a00ee23d3
   RNScreens: e902eba58a27d3ad399a495d578e8aba3ea0f490

--- a/apps/RNApp/src/HomeScreen.tsx
+++ b/apps/RNApp/src/HomeScreen.tsx
@@ -184,7 +184,13 @@ export function HomeScreen({
       </View>
 
       <Button
-        onPress={() => BrownfieldNavigation.navigateToSettings()}
+        onPress={() =>
+          BrownfieldNavigation.navigateToSettings({
+            id: '123',
+            name: 'John Doe',
+            email: 'john.doe@example.com',
+          })
+        }
         color={colors.secondary}
         title="Open native settings"
       />

--- a/apps/RNApp/src/HomeScreen.tsx
+++ b/apps/RNApp/src/HomeScreen.tsx
@@ -189,6 +189,11 @@ export function HomeScreen({
             id: '123',
             name: 'John Doe',
             email: 'john.doe@example.com',
+            flags: ['admin', 'user'],
+            ids: ['123', '456'],
+            avatar: {
+              url: 'https://example.com/avatar.png',
+            },
           })
         }
         color={colors.secondary}

--- a/packages/cli/src/navigation/__tests__/generators.test.ts
+++ b/packages/cli/src/navigation/__tests__/generators.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { generateKotlinDelegate, generateKotlinModule } from '../generators/android.js';
-import { generateObjCImplementation, generateSwiftDelegate } from '../generators/ios.js';
+import {
+  generateObjCImplementation,
+  generateSwiftDelegate,
+} from '../generators/ios.js';
 import {
   generateIndexDts,
   generateIndexTs,
@@ -51,6 +54,70 @@ describe('navigation code generators', () => {
     expect(indexDts).toContain('openScreen: (route: string, params?: Object) => void;');
   });
 
+  it('includes referenced custom type declarations in TurboModule spec', () => {
+    const turboModuleSpec = generateTurboModuleSpec(
+      [
+        {
+          name: 'navigateToSettings',
+          params: [{ name: 'user', type: 'UserType', optional: false }],
+          returnType: 'void',
+          isAsync: false,
+        },
+      ],
+      [
+        {
+          name: 'UserType',
+          declaration: 'export type UserType = { id: string; };',
+        },
+      ],
+      {
+        modelTypeNames: ['UserType'],
+      }
+    );
+
+    expect(turboModuleSpec).toContain('export type UserType = { id: string; };');
+    expect(turboModuleSpec).toContain(
+      'navigateToSettings(user: Object): void;'
+    );
+  });
+
+  it('imports referenced custom types into generated index files', () => {
+    const customTypeMethods: MethodSignature[] = [
+      {
+        name: 'navigateToSettings',
+        params: [{ name: 'user', type: 'UserType', optional: false }],
+        returnType: 'void',
+        isAsync: false,
+      },
+    ];
+    const referencedTypeDeclarations = [
+      {
+        name: 'UserType',
+        declaration: 'export type UserType = { id: string; };',
+      },
+    ];
+
+    const indexTs = generateIndexTs(
+      customTypeMethods,
+      referencedTypeDeclarations
+    );
+    const indexDts = generateIndexDts(
+      customTypeMethods,
+      referencedTypeDeclarations
+    );
+
+    expect(indexTs).toContain(
+      "import type { UserType } from './NativeBrownfieldNavigation';"
+    );
+    expect(indexTs).toContain('navigateToSettings: (user: UserType)');
+    expect(indexDts).toContain(
+      "import type { UserType } from './NativeBrownfieldNavigation';"
+    );
+    expect(indexDts).toContain(
+      'navigateToSettings: (user: UserType) => void;'
+    );
+  });
+
   it('generates iOS bindings for sync methods', () => {
     const swiftDelegate = generateSwiftDelegate(methods);
     const objcImplementation = generateObjCImplementation(methods);
@@ -86,7 +153,9 @@ describe('navigation code generators', () => {
       modelTypeNames: ['DummyType'],
     });
 
-    expect(swiftDelegate).toContain('@objc func openSettings(_ payload: DummyType)');
+    expect(swiftDelegate).toContain(
+      '@objc func openSettings(_ payload: DummyType)'
+    );
     expect(swiftDelegate).toContain(
       '@objc func openSettingsOptional(_ payload: DummyType?)'
     );
@@ -94,7 +163,9 @@ describe('navigation code generators', () => {
 
   it('maps known model types for Kotlin delegate/module signatures', () => {
     const kotlinPackageName = 'com.callstack.nativebrownfieldnavigation';
-    const options = { modelTypeNames: ['DummyType'] };
+    const options = {
+      modelTypeNames: ['DummyType'],
+    };
     const kotlinDelegate = generateKotlinDelegate(
       modelMethods,
       kotlinPackageName,
@@ -109,13 +180,41 @@ describe('navigation code generators', () => {
     expect(kotlinDelegate).toContain('fun openSettings(payload: DummyType)');
     expect(kotlinDelegate).toContain('fun openSettingsOptional(payload: DummyType?)');
     expect(kotlinModule).toContain(
-      'override fun openSettings(payload: DummyType)'
+      'override fun openSettings(payload: ReadableMap)'
     );
     expect(kotlinModule).toContain(
-      'override fun openSettingsOptional(payload: DummyType?)'
+      'override fun openSettingsOptional(payload: ReadableMap?)'
+    );
+    expect(kotlinModule).toContain(
+      'val payloadModel = payload.let(::toDummyType)'
+    );
+    expect(kotlinModule).toContain(
+      'BrownfieldNavigationManager.getDelegate().openSettings(payloadModel)'
+    );
+    expect(kotlinModule).toContain(
+      'val payloadModel = payload?.let(::toDummyType)'
     );
     expect(kotlinModule).not.toContain('payload: Any');
     expect(kotlinModule).not.toContain('payload: Any?');
+  });
+
+  it('uses NSDictionary model args and converts before delegate calls', () => {
+    const objcImplementation = generateObjCImplementation(modelMethods, {
+      modelTypeNames: ['DummyType'],
+    });
+
+    expect(objcImplementation).toContain(
+      '- (void)openSettings:(NSDictionary *)payload'
+    );
+    expect(objcImplementation).toContain(
+      '- (void)openSettingsOptional:(NSDictionary * _Nullable)payload'
+    );
+    expect(objcImplementation).toContain(
+      'DummyType *payloadModel = payload == nil ? nil : [DummyType fromDictionary:payload];'
+    );
+    expect(objcImplementation).toContain(
+      'openSettings:payloadModel'
+    );
   });
 });
 

--- a/packages/cli/src/navigation/__tests__/generators.test.ts
+++ b/packages/cli/src/navigation/__tests__/generators.test.ts
@@ -21,6 +21,21 @@ const methods: MethodSignature[] = [
   },
 ];
 
+const modelMethods: MethodSignature[] = [
+  {
+    name: 'openSettings',
+    params: [{ name: 'payload', type: 'DummyType', optional: false }],
+    returnType: 'void',
+    isAsync: false,
+  },
+  {
+    name: 'openSettingsOptional',
+    params: [{ name: 'payload', type: 'DummyType', optional: true }],
+    returnType: 'void',
+    isAsync: false,
+  },
+];
+
 describe('navigation code generators', () => {
   it('generates TurboModule spec and index files', () => {
     const turboModuleSpec = generateTurboModuleSpec(methods);
@@ -64,6 +79,43 @@ describe('navigation code generators', () => {
     expect(kotlinModule).toContain(
       'BrownfieldNavigationManager.getDelegate().openScreen(route, params)'
     );
+  });
+
+  it('maps known model types for Swift delegate signatures', () => {
+    const swiftDelegate = generateSwiftDelegate(modelMethods, {
+      modelTypeNames: ['DummyType'],
+    });
+
+    expect(swiftDelegate).toContain('@objc func openSettings(_ payload: DummyType)');
+    expect(swiftDelegate).toContain(
+      '@objc func openSettingsOptional(_ payload: DummyType?)'
+    );
+  });
+
+  it('maps known model types for Kotlin delegate/module signatures', () => {
+    const kotlinPackageName = 'com.callstack.nativebrownfieldnavigation';
+    const options = { modelTypeNames: ['DummyType'] };
+    const kotlinDelegate = generateKotlinDelegate(
+      modelMethods,
+      kotlinPackageName,
+      options
+    );
+    const kotlinModule = generateKotlinModule(
+      modelMethods,
+      kotlinPackageName,
+      options
+    );
+
+    expect(kotlinDelegate).toContain('fun openSettings(payload: DummyType)');
+    expect(kotlinDelegate).toContain('fun openSettingsOptional(payload: DummyType?)');
+    expect(kotlinModule).toContain(
+      'override fun openSettings(payload: DummyType)'
+    );
+    expect(kotlinModule).toContain(
+      'override fun openSettingsOptional(payload: DummyType?)'
+    );
+    expect(kotlinModule).not.toContain('payload: Any');
+    expect(kotlinModule).not.toContain('payload: Any?');
   });
 });
 

--- a/packages/cli/src/navigation/__tests__/models.test.ts
+++ b/packages/cli/src/navigation/__tests__/models.test.ts
@@ -95,7 +95,15 @@ describe('generateNavigationModels', () => {
           fields: [
             { name: 'id', type: 'string', optional: false },
             { name: 'name', type: 'string', optional: false },
+            { name: 'nickname', type: 'string', optional: true },
+            { name: 'avatar', type: 'Avatar', optional: true },
+            { name: 'flags', type: 'string[]', optional: false },
+            { name: 'ids', type: 'string[] | null', optional: false },
           ],
+        },
+        {
+          name: 'Avatar',
+          fields: [{ name: 'url', type: 'string', optional: false }],
         },
       ],
     });
@@ -110,12 +118,32 @@ describe('generateNavigationModels', () => {
     expect(models.swiftModels).toContain(
       'static func fromDictionary(_ value: NSDictionary) -> UserProfile'
     );
+    expect(models.swiftModels).toContain('value["nickname"] as? String');
+    expect(models.swiftModels).toContain(
+      '(value["avatar"] as? NSDictionary).map(Avatar.fromDictionary)'
+    );
+    expect(models.swiftModels).toContain('@objc public extension Avatar');
+    expect(models.swiftModels).toContain('flags: value["flags"] as! [String]');
+    expect(models.swiftModels).toContain('ids: value["ids"] as? [String]');
     expect(models.kotlinModels).toContain('data class UserProfile');
     expect(models.kotlinModels).toContain(
       'import com.facebook.react.bridge.ReadableMap'
     );
     expect(models.kotlinModels).toContain(
       'fun toUserProfile(value: ReadableMap): UserProfile'
+    );
+    expect(models.kotlinModels).toContain('value.getString("nickname")');
+    expect(models.kotlinModels).toContain(
+      'value.getMap("avatar")?.let { toAvatar(it) }'
+    );
+    expect(models.kotlinModels).toContain(
+      'fun toAvatar(value: ReadableMap): Avatar'
+    );
+    expect(models.kotlinModels).toContain(
+      'flags = readStringArray(value, "flags", true)!!'
+    );
+    expect(models.kotlinModels).toContain(
+      'ids = readStringArray(value, "ids", false)'
     );
     expect(addSourceMock).toHaveBeenCalled();
     expect(quicktypeMock).toHaveBeenCalledTimes(2);

--- a/packages/cli/src/navigation/__tests__/models.test.ts
+++ b/packages/cli/src/navigation/__tests__/models.test.ts
@@ -8,7 +8,10 @@ const { addSourceMock, quicktypeMock } = vi.hoisted(() => ({
   quicktypeMock: vi.fn(async ({ lang }: { lang: 'swift' | 'kotlin' }) => ({
     lines:
       lang === 'swift'
-        ? ['public struct UserProfile {}', 'public struct SessionResult {}']
+        ? [
+            '@objcMembers public class UserProfile: NSObject, Codable {}',
+            '@objcMembers public class SessionResult: NSObject, Codable {}',
+          ]
         : ['data class UserProfile()', 'data class SessionResult()'],
   })),
 }));
@@ -86,11 +89,34 @@ describe('generateNavigationModels', () => {
       specPath,
       methods,
       kotlinPackageName: 'com.callstack.nativebrownfieldnavigation',
+      modelDefinitions: [
+        {
+          name: 'UserProfile',
+          fields: [
+            { name: 'id', type: 'string', optional: false },
+            { name: 'name', type: 'string', optional: false },
+          ],
+        },
+      ],
     });
 
     expect(models.modelTypeNames).toEqual(['UserProfile']);
-    expect(models.swiftModels).toContain('public struct UserProfile');
+    expect(models.swiftModels).toContain(
+      '@objcMembers public class UserProfile: NSObject, Codable'
+    );
+    expect(models.swiftModels).toContain(
+      '@objc public extension UserProfile'
+    );
+    expect(models.swiftModels).toContain(
+      'static func fromDictionary(_ value: NSDictionary) -> UserProfile'
+    );
     expect(models.kotlinModels).toContain('data class UserProfile');
+    expect(models.kotlinModels).toContain(
+      'import com.facebook.react.bridge.ReadableMap'
+    );
+    expect(models.kotlinModels).toContain(
+      'fun toUserProfile(value: ReadableMap): UserProfile'
+    );
     expect(addSourceMock).toHaveBeenCalled();
     expect(quicktypeMock).toHaveBeenCalledTimes(2);
   });

--- a/packages/cli/src/navigation/__tests__/parser.test.ts
+++ b/packages/cli/src/navigation/__tests__/parser.test.ts
@@ -34,9 +34,9 @@ describe('parseNavigationSpec', () => {
     `);
     tempSpecFiles.push(specPath);
 
-    const methods = parseNavigationSpec(specPath);
+    const parsedSpec = parseNavigationSpec(specPath);
 
-    expect(methods).toEqual([
+    expect(parsedSpec.methods).toEqual([
       {
         name: 'openScreen',
         params: [
@@ -47,6 +47,8 @@ describe('parseNavigationSpec', () => {
         isAsync: false,
       },
     ]);
+    expect(parsedSpec.referencedTypeDeclarations).toEqual([]);
+    expect(parsedSpec.modelDefinitions).toEqual([]);
   });
 
   it('falls back to Spec interface when BrownfieldNavigationSpec is absent', () => {
@@ -57,14 +59,72 @@ describe('parseNavigationSpec', () => {
     `);
     tempSpecFiles.push(specPath);
 
-    const methods = parseNavigationSpec(specPath);
+    const parsedSpec = parseNavigationSpec(specPath);
 
-    expect(methods).toEqual([
+    expect(parsedSpec.methods).toEqual([
       {
         name: 'presentModal',
         params: [{ name: 'id', type: 'string', optional: false }],
         returnType: 'number',
         isAsync: false,
+      },
+    ]);
+    expect(parsedSpec.referencedTypeDeclarations).toEqual([]);
+    expect(parsedSpec.modelDefinitions).toEqual([]);
+  });
+
+  it('collects referenced type declarations used in method signatures', () => {
+    const specPath = createTempSpecFile(`
+      export type UserType = {
+        name: string;
+      };
+
+      export interface BrownfieldNavigationSpec {
+        navigateToSettings(user: UserType): void;
+      }
+    `);
+    tempSpecFiles.push(specPath);
+
+    const parsedSpec = parseNavigationSpec(specPath);
+
+    expect(parsedSpec.referencedTypeDeclarations).toEqual([
+      {
+        name: 'UserType',
+        declaration: `export type UserType = {\n        name: string;\n      };`,
+      },
+    ]);
+    expect(parsedSpec.modelDefinitions).toEqual([
+      {
+        name: 'UserType',
+        fields: [{ name: 'name', type: 'string', optional: false }],
+      },
+    ]);
+  });
+
+  it('exports referenced declarations even when source declarations are not exported', () => {
+    const specPath = createTempSpecFile(`
+      type UserType = {
+        name: string;
+      };
+
+      interface BrownfieldNavigationSpec {
+        navigateToSettings(user: UserType): void;
+      }
+    `);
+    tempSpecFiles.push(specPath);
+
+    const parsedSpec = parseNavigationSpec(specPath);
+
+    expect(parsedSpec.referencedTypeDeclarations).toEqual([
+      {
+        name: 'UserType',
+        declaration: `export type UserType = {\n        name: string;\n      };`,
+      },
+    ]);
+    expect(parsedSpec.modelDefinitions).toEqual([
+      {
+        name: 'UserType',
+        fields: [{ name: 'name', type: 'string', optional: false }],
       },
     ]);
   });

--- a/packages/cli/src/navigation/__tests__/runner.integration.test.ts
+++ b/packages/cli/src/navigation/__tests__/runner.integration.test.ts
@@ -22,7 +22,7 @@ vi.mock('../generators/ts', async (importOriginal) => {
 });
 
 vi.mock('../generators/models', () => ({
-  generateNavigationModels: vi.fn(async () => ({ modelTypeNames: [] })),
+  generateNavigationModels: vi.fn(async () => ({ modelTypeNames: ['UserType'] })),
 }));
 
 import { runNavigationCodegen } from '../runner.js';
@@ -78,8 +78,13 @@ describe('runNavigationCodegen integration', () => {
     fs.writeFileSync(
       path.join(projectRoot, 'brownfield.navigation.ts'),
       `
+      export type UserType = {
+        id: string;
+      };
+
       export interface BrownfieldNavigationSpec {
         openScreen(route: string, params?: Object): void;
+        navigateToSettings(user: UserType): void;
         fetchToken(userId: string): Promise<string>;
       }
       `
@@ -116,7 +121,16 @@ describe('runNavigationCodegen integration', () => {
     expect(fs.existsSync(kotlinModulePath)).toBe(true);
 
     expect(fs.readFileSync(turboModuleSpecPath, 'utf8')).toContain('openScreen');
+    expect(fs.readFileSync(turboModuleSpecPath, 'utf8')).toContain(
+      'export type UserType = {\n        id: string;\n      };'
+    );
+    expect(fs.readFileSync(turboModuleSpecPath, 'utf8')).toContain(
+      'navigateToSettings(user: Object): void;'
+    );
     expect(fs.readFileSync(indexTsPath, 'utf8')).toContain('fetchToken');
+    expect(fs.readFileSync(indexTsPath, 'utf8')).toContain(
+      "import type { UserType } from './NativeBrownfieldNavigation';"
+    );
     expect(fs.readFileSync(swiftDelegatePath, 'utf8')).toContain(
       '@objc public protocol BrownfieldNavigationDelegate'
     );

--- a/packages/cli/src/navigation/generators/android.ts
+++ b/packages/cli/src/navigation/generators/android.ts
@@ -15,11 +15,12 @@ interface KotlinTypeMappingOptions {
 function mapTsTypeToKotlin(
   tsType: string,
   optional: boolean = false,
-  options: KotlinTypeMappingOptions = {}
+  options: KotlinTypeMappingOptions = {},
+  layer: 'delegate' | 'module' = 'delegate'
 ): string {
   if (tsType.startsWith('Promise<')) {
     const inner = tsType.slice(8, -1);
-    return mapTsTypeToKotlin(inner, optional, options);
+    return mapTsTypeToKotlin(inner, optional, options, layer);
   }
 
   const mapped = TS_TO_KOTLIN_TYPE[tsType];
@@ -28,6 +29,9 @@ function mapTsTypeToKotlin(
   }
 
   if (options.modelTypeNames?.includes(tsType)) {
+    if (layer === 'module') {
+      return optional ? 'ReadableMap?' : 'ReadableMap';
+    }
     return optional ? `${tsType}?` : tsType;
   }
 
@@ -50,7 +54,7 @@ export function generateKotlinDelegate(
       const returnType =
         method.returnType === 'void'
           ? ''
-          : `: ${mapTsTypeToKotlin(method.returnType, false, options)}`;
+          : `: ${mapTsTypeToKotlin(method.returnType, false, options, 'delegate')}`;
       return `  fun ${method.name}(${params})${returnType}`;
     })
     .join('\n');
@@ -72,7 +76,10 @@ export function generateKotlinModule(
   const hasObjectType = methods.some(
     (method) =>
       method.returnType.includes('Object') ||
-      method.params.some((param) => param.type === 'Object')
+      method.params.some(
+        (param) =>
+          param.type === 'Object' || options.modelTypeNames?.includes(param.type)
+      )
   );
 
   const methodImplementations = methods
@@ -107,24 +114,44 @@ function generateSyncKotlinMethod(
   options: KotlinTypeMappingOptions = {}
 ): string {
   const params = method.params
-    .map((param) => `${param.name}: ${mapTsTypeToKotlin(param.type, param.optional, options)}`)
+    .map(
+      (param) =>
+        `${param.name}: ${mapTsTypeToKotlin(param.type, param.optional, options, 'module')}`
+    )
     .join(', ');
-  const args = method.params.map((param) => param.name).join(', ');
+  const preparedParams: string[] = [];
+  const args = method.params
+    .map((param) => {
+      if (options.modelTypeNames?.includes(param.type)) {
+        const convertedName = `${param.name}Model`;
+        preparedParams.push(
+          `    val ${convertedName} = ${param.name}${
+            param.optional
+              ? `?.let(::to${param.type})`
+              : `.let(::to${param.type})`
+          }`
+        );
+        return convertedName;
+      }
+      return param.name;
+    })
+    .join(', ');
 
   const signature = `  @ReactMethod\n  override fun ${method.name}(${params})${
     method.returnType === 'void'
       ? ''
-      : `: ${mapTsTypeToKotlin(method.returnType, false, options)}`
+      : `: ${mapTsTypeToKotlin(method.returnType, false, options, 'module')}`
   }`;
+  const preparedPrefix = preparedParams.length > 0 ? `${preparedParams.join('\n')}\n` : '';
 
   if (method.returnType === 'void') {
     return `${signature} {
-    BrownfieldNavigationManager.getDelegate().${method.name}(${args})
+${preparedPrefix}    BrownfieldNavigationManager.getDelegate().${method.name}(${args})
   }`;
   }
 
   return `${signature} {
-    return BrownfieldNavigationManager.getDelegate().${method.name}(${args})
+${preparedPrefix}    return BrownfieldNavigationManager.getDelegate().${method.name}(${args})
   }`;
 }
 
@@ -133,7 +160,10 @@ function generateAsyncKotlinMethod(
   options: KotlinTypeMappingOptions = {}
 ): string {
   const paramsWithTypes = method.params
-    .map((param) => `${param.name}: ${mapTsTypeToKotlin(param.type, param.optional, options)}`)
+    .map(
+      (param) =>
+        `${param.name}: ${mapTsTypeToKotlin(param.type, param.optional, options, 'module')}`
+    )
     .join(', ');
   const params =
     paramsWithTypes.length > 0

--- a/packages/cli/src/navigation/generators/android.ts
+++ b/packages/cli/src/navigation/generators/android.ts
@@ -8,10 +8,18 @@ const TS_TO_KOTLIN_TYPE: Record<string, string> = {
   Object: 'ReadableMap',
 };
 
-function mapTsTypeToKotlin(tsType: string, optional: boolean = false): string {
+interface KotlinTypeMappingOptions {
+  modelTypeNames?: string[];
+}
+
+function mapTsTypeToKotlin(
+  tsType: string,
+  optional: boolean = false,
+  options: KotlinTypeMappingOptions = {}
+): string {
   if (tsType.startsWith('Promise<')) {
     const inner = tsType.slice(8, -1);
-    return mapTsTypeToKotlin(inner, optional);
+    return mapTsTypeToKotlin(inner, optional, options);
   }
 
   const mapped = TS_TO_KOTLIN_TYPE[tsType];
@@ -19,25 +27,30 @@ function mapTsTypeToKotlin(tsType: string, optional: boolean = false): string {
     return optional ? `${mapped}?` : mapped;
   }
 
+  if (options.modelTypeNames?.includes(tsType)) {
+    return optional ? `${tsType}?` : tsType;
+  }
+
   return optional ? 'Any?' : 'Any';
 }
 
 export function generateKotlinDelegate(
   methods: MethodSignature[],
-  kotlinPackageName: string
+  kotlinPackageName: string,
+  options: KotlinTypeMappingOptions = {}
 ): string {
   const methodSignatures = methods
     .map((method) => {
       const params = method.params
         .map(
           (param) =>
-            `${param.name}: ${mapTsTypeToKotlin(param.type, param.optional)}`
+            `${param.name}: ${mapTsTypeToKotlin(param.type, param.optional, options)}`
         )
         .join(', ');
       const returnType =
         method.returnType === 'void'
           ? ''
-          : `: ${mapTsTypeToKotlin(method.returnType, false)}`;
+          : `: ${mapTsTypeToKotlin(method.returnType, false, options)}`;
       return `  fun ${method.name}(${params})${returnType}`;
     })
     .join('\n');
@@ -52,7 +65,8 @@ ${methodSignatures}
 
 export function generateKotlinModule(
   methods: MethodSignature[],
-  kotlinPackageName: string
+  kotlinPackageName: string,
+  options: KotlinTypeMappingOptions = {}
 ): string {
   const hasAsyncMethod = methods.some((method) => method.isAsync);
   const hasObjectType = methods.some(
@@ -64,8 +78,8 @@ export function generateKotlinModule(
   const methodImplementations = methods
     .map((method) =>
       method.isAsync
-        ? generateAsyncKotlinMethod(method)
-        : generateSyncKotlinMethod(method)
+        ? generateAsyncKotlinMethod(method, options)
+        : generateSyncKotlinMethod(method, options)
     )
     .join('\n\n');
 
@@ -88,16 +102,19 @@ ${methodImplementations}
 `;
 }
 
-function generateSyncKotlinMethod(method: MethodSignature): string {
+function generateSyncKotlinMethod(
+  method: MethodSignature,
+  options: KotlinTypeMappingOptions = {}
+): string {
   const params = method.params
-    .map((param) => `${param.name}: ${mapTsTypeToKotlin(param.type, param.optional)}`)
+    .map((param) => `${param.name}: ${mapTsTypeToKotlin(param.type, param.optional, options)}`)
     .join(', ');
   const args = method.params.map((param) => param.name).join(', ');
 
   const signature = `  @ReactMethod\n  override fun ${method.name}(${params})${
     method.returnType === 'void'
       ? ''
-      : `: ${mapTsTypeToKotlin(method.returnType, false)}`
+      : `: ${mapTsTypeToKotlin(method.returnType, false, options)}`
   }`;
 
   if (method.returnType === 'void') {
@@ -111,9 +128,12 @@ function generateSyncKotlinMethod(method: MethodSignature): string {
   }`;
 }
 
-function generateAsyncKotlinMethod(method: MethodSignature): string {
+function generateAsyncKotlinMethod(
+  method: MethodSignature,
+  options: KotlinTypeMappingOptions = {}
+): string {
   const paramsWithTypes = method.params
-    .map((param) => `${param.name}: ${mapTsTypeToKotlin(param.type, param.optional)}`)
+    .map((param) => `${param.name}: ${mapTsTypeToKotlin(param.type, param.optional, options)}`)
     .join(', ');
   const params =
     paramsWithTypes.length > 0

--- a/packages/cli/src/navigation/generators/ios.ts
+++ b/packages/cli/src/navigation/generators/ios.ts
@@ -16,9 +16,21 @@ const TS_TO_SWIFT_TYPE: Record<string, string> = {
   Object: '[String: Any]',
 };
 
-function mapTsTypeToObjC(tsType: string, nullable: boolean = false): string {
+interface ObjCTypeMappingOptions {
+  modelTypeNames?: string[];
+}
+
+function mapTsTypeToObjC(
+  tsType: string,
+  nullable: boolean = false,
+  options: ObjCTypeMappingOptions = {}
+): string {
   if (tsType.startsWith('Promise<')) {
     return 'void';
+  }
+
+  if (options.modelTypeNames?.includes(tsType)) {
+    return nullable ? 'NSDictionary * _Nullable' : 'NSDictionary *';
   }
 
   const mapped = TS_TO_OBJC_TYPE[tsType];
@@ -35,6 +47,8 @@ function mapTsTypeToObjC(tsType: string, nullable: boolean = false): string {
 interface SwiftTypeMappingOptions {
   modelTypeNames?: string[];
 }
+
+interface ObjCGenerationOptions extends ObjCTypeMappingOptions {}
 
 function mapTsTypeToSwift(
   tsType: string,
@@ -89,10 +103,15 @@ ${protocolMethods}
 `;
 }
 
-export function generateObjCImplementation(methods: MethodSignature[]): string {
+export function generateObjCImplementation(
+  methods: MethodSignature[],
+  options: ObjCGenerationOptions = {}
+): string {
   const methodImplementations = methods
     .map((method) =>
-      method.isAsync ? generateAsyncObjCMethod(method) : generateSyncObjCMethod(method)
+      method.isAsync
+        ? generateAsyncObjCMethod(method, options)
+        : generateSyncObjCMethod(method, options)
     )
     .join('\n\n');
 
@@ -123,38 +142,61 @@ ${methodImplementations}
 `;
 }
 
-function generateSyncObjCMethod(method: MethodSignature): string {
+function generateSyncObjCMethod(
+  method: MethodSignature,
+  options: ObjCGenerationOptions
+): string {
   const { name, params, returnType } = method;
 
-  let signature = `- (${mapTsTypeToObjC(returnType)})${name}`;
+  let signature = `- (${mapTsTypeToObjC(returnType, false, options)})${name}`;
   if (params.length > 0) {
     signature += params
       .map((param, index) => {
         const prefix = index === 0 ? ':' : ` ${param.name}:`;
-        return `${prefix}(${mapTsTypeToObjC(param.type, param.optional)})${param.name}`;
+        return `${prefix}(${mapTsTypeToObjC(param.type, param.optional, options)})${param.name}`;
       })
       .join('');
   }
 
+  const preparedParams: string[] = [];
+  const delegateArgs: string[] = [];
+  for (const param of params) {
+    if (options.modelTypeNames?.includes(param.type)) {
+      const convertedParamName = `${param.name}Model`;
+      preparedParams.push(
+        `${param.type} *${convertedParamName} = ${param.name} == nil ? nil : [${param.type} fromDictionary:${param.name}];`
+      );
+      delegateArgs.push(convertedParamName);
+    } else {
+      delegateArgs.push(param.name);
+    }
+  }
+
   let delegateCall = `[[[BrownfieldNavigationManager shared] getDelegate] ${name}`;
-  if (params.length > 0) {
-    delegateCall += params
-      .map((param, index) => {
+  if (delegateArgs.length > 0) {
+    delegateCall += delegateArgs
+      .map((argName, index) => {
+        const param = params[index];
         const label = index === 0 ? '' : param.name;
-        return `${label}:${param.name}`;
+        return `${label}:${argName}`;
       })
       .join(' ');
   }
   delegateCall += ']';
 
   const returnPrefix = returnType === 'void' ? '' : 'return ';
+  const preparedLines = preparedParams.map((line) => `    ${line}`).join('\n');
+  const bodyPrefix = preparedLines.length > 0 ? `${preparedLines}\n` : '';
 
   return `${signature} {
-    ${returnPrefix}${delegateCall};
+${bodyPrefix}    ${returnPrefix}${delegateCall};
 }`;
 }
 
-function generateAsyncObjCMethod(method: MethodSignature): string {
+function generateAsyncObjCMethod(
+  method: MethodSignature,
+  options: ObjCGenerationOptions
+): string {
   const { name, params } = method;
 
   let signature = `- (void)${name}`;
@@ -173,7 +215,7 @@ function generateAsyncObjCMethod(method: MethodSignature): string {
           ? 'RCTPromiseResolveBlock'
           : param.type === 'RCTPromiseRejectBlock'
             ? 'RCTPromiseRejectBlock'
-            : mapTsTypeToObjC(param.type, param.optional);
+            : mapTsTypeToObjC(param.type, param.optional, options);
       return `${prefix}(${type})${param.name}`;
     })
     .join(' ');

--- a/packages/cli/src/navigation/generators/ios.ts
+++ b/packages/cli/src/navigation/generators/ios.ts
@@ -32,10 +32,18 @@ function mapTsTypeToObjC(tsType: string, nullable: boolean = false): string {
   return nullable ? 'id _Nullable' : 'id';
 }
 
-function mapTsTypeToSwift(tsType: string, optional: boolean = false): string {
+interface SwiftTypeMappingOptions {
+  modelTypeNames?: string[];
+}
+
+function mapTsTypeToSwift(
+  tsType: string,
+  optional: boolean = false,
+  options: SwiftTypeMappingOptions = {}
+): string {
   if (tsType.startsWith('Promise<')) {
     const inner = tsType.slice(8, -1);
-    return mapTsTypeToSwift(inner, optional);
+    return mapTsTypeToSwift(inner, optional, options);
   }
 
   const mapped = TS_TO_SWIFT_TYPE[tsType];
@@ -43,15 +51,22 @@ function mapTsTypeToSwift(tsType: string, optional: boolean = false): string {
     return optional ? `${mapped}?` : mapped;
   }
 
+  if (options.modelTypeNames?.includes(tsType)) {
+    return optional ? `${tsType}?` : tsType;
+  }
+
   return optional ? 'Any?' : 'Any';
 }
 
-export function generateSwiftDelegate(methods: MethodSignature[]): string {
+export function generateSwiftDelegate(
+  methods: MethodSignature[],
+  options: SwiftTypeMappingOptions = {}
+): string {
   const protocolMethods = methods
     .map((method) => {
       const params = method.params
         .map((param, index) => {
-          const swiftType = mapTsTypeToSwift(param.type, param.optional);
+          const swiftType = mapTsTypeToSwift(param.type, param.optional, options);
           const label = index === 0 ? '_' : param.name;
           return `${label} ${param.name}: ${swiftType}`;
         })
@@ -60,7 +75,7 @@ export function generateSwiftDelegate(methods: MethodSignature[]): string {
       const returnType =
         method.returnType === 'void'
           ? ''
-          : ` -> ${mapTsTypeToSwift(method.returnType, false)}`;
+          : ` -> ${mapTsTypeToSwift(method.returnType, false, options)}`;
 
       return `    @objc func ${method.name}(${params})${returnType}`;
     })

--- a/packages/cli/src/navigation/generators/models.ts
+++ b/packages/cli/src/navigation/generators/models.ts
@@ -206,13 +206,17 @@ function generateSwiftModelConversionExtensions(
   modelDefinitions: ModelDefinition[],
   modelTypeNames: string[]
 ): string {
-  const modelDefinitionsByName = new Map(
-    modelDefinitions.map((definition) => [definition.name, definition])
+  const modelDefinitionsByLookupName = buildModelDefinitionsByLookupName(
+    modelDefinitions
+  );
+  const conversionModelNames = collectConversionModelNames(
+    modelDefinitionsByLookupName,
+    modelTypeNames
   );
 
-  return modelTypeNames
+  return conversionModelNames
     .map((modelName) => {
-      const definition = modelDefinitionsByName.get(modelName);
+      const definition = modelDefinitionsByLookupName.get(modelName);
       if (!definition) {
         return '';
       }
@@ -229,7 +233,8 @@ function generateSwiftModelConversionExtensions(
           (field) =>
             `${field.name}: ${mapDictionaryValueToSwiftExpression(
               field.name,
-              field.type
+              field.type,
+              field.optional
             )}`
         )
         .join(', ');
@@ -246,32 +251,56 @@ function generateSwiftModelConversionExtensions(
 
 function mapDictionaryValueToSwiftExpression(
   fieldName: string,
-  fieldType: string
+  fieldType: string,
+  optional: boolean
 ): string {
+  const parsedType = parseFieldType(fieldType);
+  const normalizedFieldType = parsedType.normalizedType;
   const valueAccess = `value["${fieldName}"]`;
-  if (fieldType === 'string') {
-    return `${valueAccess} as! String`;
+  const allowsNil = optional || parsedType.nullable;
+  if (normalizedFieldType === 'string') {
+    return allowsNil ? `${valueAccess} as? String` : `${valueAccess} as! String`;
   }
-  if (fieldType === 'number') {
-    return `(${valueAccess} as! NSNumber).doubleValue`;
+  if (normalizedFieldType === 'number') {
+    return allowsNil
+      ? `(${valueAccess} as? NSNumber)?.doubleValue`
+      : `(${valueAccess} as! NSNumber).doubleValue`;
   }
-  if (fieldType === 'boolean') {
-    return `(${valueAccess} as! NSNumber).boolValue`;
+  if (normalizedFieldType === 'boolean') {
+    return allowsNil
+      ? `(${valueAccess} as? NSNumber)?.boolValue`
+      : `(${valueAccess} as! NSNumber).boolValue`;
   }
-  return `${fieldType}.fromDictionary(${valueAccess} as! NSDictionary)`;
+  if (normalizedFieldType === 'string[]') {
+    return allowsNil ? `${valueAccess} as? [String]` : `${valueAccess} as! [String]`;
+  }
+
+  if (isSimpleTypeReference(normalizedFieldType)) {
+    const nestedModelType = resolveNestedModelTypeName(normalizedFieldType);
+    return allowsNil
+      ? `(${valueAccess} as? NSDictionary).map(${nestedModelType}.fromDictionary)`
+      : `${nestedModelType}.fromDictionary(${valueAccess} as! NSDictionary)`;
+  }
+
+  return `fatalError("Unsupported TypeScript field type '${escapeSwiftStringLiteral(normalizedFieldType)}' for field '${escapeSwiftStringLiteral(fieldName)}' in Swift conversion. Consider using 'Any' or a custom converter.")`;
 }
 
 function generateKotlinModelConversionExtensions(
   modelDefinitions: ModelDefinition[],
   modelTypeNames: string[]
 ): string {
-  const modelDefinitionsByName = new Map(
-    modelDefinitions.map((definition) => [definition.name, definition])
+  const modelDefinitionsByLookupName = buildModelDefinitionsByLookupName(
+    modelDefinitions
   );
+  const conversionModelNames = collectConversionModelNames(
+    modelDefinitionsByLookupName,
+    modelTypeNames
+  );
+  let usesStringArrayHelper = false;
 
-  return modelTypeNames
+  const conversionFunctions = conversionModelNames
     .map((modelName) => {
-      const definition = modelDefinitionsByName.get(modelName);
+      const definition = modelDefinitionsByLookupName.get(modelName);
       if (!definition) {
         return '';
       }
@@ -284,10 +313,18 @@ function generateKotlinModelConversionExtensions(
       }
 
       const args = sortedFields
-        .map(
-          (field) =>
-            `${field.name} = ${mapReadableMapFieldExpression('value', field.name, field.type)}`
-        )
+        .map((field) => {
+          const fieldExpression = mapReadableMapFieldExpression(
+            'value',
+            field.name,
+            field.type,
+            field.optional
+          );
+          if (fieldExpression.includes('readStringArray(')) {
+            usesStringArrayHelper = true;
+          }
+          return `${field.name} = ${fieldExpression}`;
+        })
         .join(', ');
 
       return `fun to${modelName}(value: ReadableMap): ${modelName} {
@@ -296,21 +333,154 @@ function generateKotlinModelConversionExtensions(
     })
     .filter(Boolean)
     .join('\n\n');
+
+  if (!usesStringArrayHelper) {
+    return conversionFunctions;
+  }
+
+  const stringArrayHelper = `private fun readStringArray(value: ReadableMap, key: String, required: Boolean): List<String>? {
+    if (!value.hasKey(key) || value.isNull(key)) {
+        if (required) error("Missing required array field '$key'")
+        return null
+    }
+    val array = value.getArray(key) ?: return null
+    return array.toArrayList().map {
+        it as? String ?: error("Expected string elements for array field '$key'")
+    }
+}`;
+
+  return conversionFunctions
+    ? `${conversionFunctions}\n\n${stringArrayHelper}`
+    : stringArrayHelper;
 }
 
 function mapReadableMapFieldExpression(
   mapName: string,
   fieldName: string,
-  fieldType: string
+  fieldType: string,
+  optional: boolean
 ): string {
-  if (fieldType === 'string') {
-    return `${mapName}.getString("${fieldName}")!!`;
+  const parsedType = parseFieldType(fieldType);
+  const normalizedFieldType = parsedType.normalizedType;
+  const allowsNull = optional || parsedType.nullable;
+  if (normalizedFieldType === 'string') {
+    return allowsNull
+      ? `${mapName}.getString("${fieldName}")`
+      : `${mapName}.getString("${fieldName}")!!`;
   }
-  if (fieldType === 'number') {
-    return `${mapName}.getDouble("${fieldName}")`;
+  if (normalizedFieldType === 'number') {
+    return allowsNull
+      ? `if (${mapName}.hasKey("${fieldName}") && !${mapName}.isNull("${fieldName}")) ${mapName}.getDouble("${fieldName}") else null`
+      : `${mapName}.getDouble("${fieldName}")`;
   }
-  if (fieldType === 'boolean') {
-    return `${mapName}.getBoolean("${fieldName}")`;
+  if (normalizedFieldType === 'boolean') {
+    return allowsNull
+      ? `if (${mapName}.hasKey("${fieldName}") && !${mapName}.isNull("${fieldName}")) ${mapName}.getBoolean("${fieldName}") else null`
+      : `${mapName}.getBoolean("${fieldName}")`;
   }
-  return `to${fieldType}(${mapName}.getMap("${fieldName}")!!)`;
+  if (normalizedFieldType === 'string[]') {
+    return allowsNull
+      ? `readStringArray(${mapName}, "${fieldName}", false)`
+      : `readStringArray(${mapName}, "${fieldName}", true)!!`;
+  }
+  if (isSimpleTypeReference(normalizedFieldType)) {
+    const nestedModelType = resolveNestedModelTypeName(normalizedFieldType);
+    return allowsNull
+      ? `${mapName}.getMap("${fieldName}")?.let { to${nestedModelType}(it) }`
+      : `to${nestedModelType}(${mapName}.getMap("${fieldName}")!!)`;
+  }
+  return `error("Unsupported TypeScript field type '${escapeKotlinStringLiteral(normalizedFieldType)}' for field '${escapeKotlinStringLiteral(fieldName)}' in Kotlin conversion. Consider using 'Any' or a custom converter.")`;
+}
+
+function isSimpleTypeReference(typeName: string): boolean {
+  return /^[A-Za-z_]\w*$/.test(typeName);
+}
+
+function escapeSwiftStringLiteral(value: string): string {
+  return value.replaceAll('\\', '\\\\').replaceAll('"', '\\"');
+}
+
+function escapeKotlinStringLiteral(value: string): string {
+  return value.replaceAll('\\', '\\\\').replaceAll('"', '\\"');
+}
+
+function parseFieldType(fieldType: string): {
+  normalizedType: string;
+  nullable: boolean;
+} {
+  const unionTypes = fieldType
+    .split('|')
+    .map((part) => part.trim())
+    .filter(Boolean);
+  const nullable = unionTypes.includes('null') || unionTypes.includes('undefined');
+  const nonNullableTypes = unionTypes.filter(
+    (part) => part !== 'null' && part !== 'undefined'
+  );
+  const normalizedType =
+    nonNullableTypes.length === 1 ? nonNullableTypes[0] : fieldType.trim();
+  return { normalizedType, nullable };
+}
+
+function resolveNestedModelTypeName(typeName: string): string {
+  if (typeName.endsWith('Type') && typeName.length > 'Type'.length) {
+    return typeName.slice(0, -'Type'.length);
+  }
+  return typeName;
+}
+
+function buildModelDefinitionsByLookupName(
+  modelDefinitions: ModelDefinition[]
+): Map<string, ModelDefinition> {
+  const definitionsByLookupName = new Map<string, ModelDefinition>();
+  for (const definition of modelDefinitions) {
+    if (!definitionsByLookupName.has(definition.name)) {
+      definitionsByLookupName.set(definition.name, definition);
+    }
+    const nestedName = resolveNestedModelTypeName(definition.name);
+    if (
+      nestedName !== definition.name &&
+      !definitionsByLookupName.has(nestedName)
+    ) {
+      definitionsByLookupName.set(nestedName, definition);
+    }
+  }
+  return definitionsByLookupName;
+}
+
+function collectConversionModelNames(
+  modelDefinitionsByLookupName: Map<string, ModelDefinition>,
+  modelTypeNames: string[]
+): string[] {
+  const queue = [...modelTypeNames];
+  const visited = new Set<string>();
+  const orderedModelNames: string[] = [];
+
+  while (queue.length > 0) {
+    const modelName = queue.shift();
+    if (!modelName || visited.has(modelName)) {
+      continue;
+    }
+    visited.add(modelName);
+
+    const definition = modelDefinitionsByLookupName.get(modelName);
+    if (!definition) {
+      continue;
+    }
+    orderedModelNames.push(modelName);
+
+    for (const field of definition.fields) {
+      const parsedFieldType = parseFieldType(field.type);
+      if (!isSimpleTypeReference(parsedFieldType.normalizedType)) {
+        continue;
+      }
+      const nestedModelName = resolveNestedModelTypeName(
+        parsedFieldType.normalizedType
+      );
+      if (!visited.has(nestedModelName)) {
+        queue.push(nestedModelName);
+      }
+    }
+  }
+
+  return orderedModelNames;
 }

--- a/packages/cli/src/navigation/generators/models.ts
+++ b/packages/cli/src/navigation/generators/models.ts
@@ -8,12 +8,13 @@ import {
 } from 'quicktype-core';
 import { schemaForTypeScriptSources } from 'quicktype-typescript-input';
 
-import type { MethodSignature } from '../types.js';
+import type { MethodSignature, ModelDefinition } from '../types.js';
 
 export interface NavigationModelsOptions {
   specPath: string;
   methods: MethodSignature[];
   kotlinPackageName: string;
+  modelDefinitions?: ModelDefinition[];
 }
 
 export interface GeneratedNavigationModels {
@@ -102,6 +103,8 @@ async function generateModelsForLanguage({
           'access-level': 'public',
           'mutable-properties': 'true',
           initializers: 'false',
+          'struct-or-class': 'class',
+          'objective-c-support': 'true',
           'swift-5-support': 'true',
         }
       : {
@@ -122,6 +125,7 @@ export async function generateNavigationModels({
   specPath,
   methods,
   kotlinPackageName,
+  modelDefinitions = [],
 }: NavigationModelsOptions): Promise<GeneratedNavigationModels> {
   const absoluteSpecPath = path.resolve(process.cwd(), specPath);
 
@@ -162,9 +166,151 @@ export async function generateNavigationModels({
     }),
   ]);
 
+  const swiftModelConversions = generateSwiftModelConversionExtensions(
+    modelDefinitions,
+    modelTypeNames
+  );
+  const kotlinModelConversions = generateKotlinModelConversionExtensions(
+    modelDefinitions,
+    modelTypeNames
+  );
+
   return {
-    swiftModels,
-    kotlinModels,
+    swiftModels: swiftModelConversions
+      ? `${swiftModels}\n\n${swiftModelConversions}`
+      : swiftModels,
+    kotlinModels: kotlinModelConversions
+      ? `${ensureKotlinReadableMapImport(kotlinModels)}\n\n${kotlinModelConversions}`
+      : kotlinModels,
     modelTypeNames,
   };
+}
+
+function ensureKotlinReadableMapImport(kotlinModels: string): string {
+  const importLine = 'import com.facebook.react.bridge.ReadableMap';
+  if (kotlinModels.includes(importLine)) {
+    return kotlinModels;
+  }
+
+  const packageMatch = kotlinModels.match(/^package[^\n]*\n/);
+  if (!packageMatch) {
+    return `${importLine}\n${kotlinModels}`;
+  }
+
+  const packageLine = packageMatch[0];
+  const rest = kotlinModels.slice(packageLine.length);
+  return `${packageLine}\n${importLine}\n${rest}`;
+}
+
+function generateSwiftModelConversionExtensions(
+  modelDefinitions: ModelDefinition[],
+  modelTypeNames: string[]
+): string {
+  const modelDefinitionsByName = new Map(
+    modelDefinitions.map((definition) => [definition.name, definition])
+  );
+
+  return modelTypeNames
+    .map((modelName) => {
+      const definition = modelDefinitionsByName.get(modelName);
+      if (!definition) {
+        return '';
+      }
+
+      const sortedFields = [...definition.fields].sort((a, b) =>
+        a.name.localeCompare(b.name)
+      );
+      if (sortedFields.length === 0) {
+        return '';
+      }
+
+      const args = sortedFields
+        .map(
+          (field) =>
+            `${field.name}: ${mapDictionaryValueToSwiftExpression(
+              field.name,
+              field.type
+            )}`
+        )
+        .join(', ');
+
+      return `@objc public extension ${modelName} {
+    static func fromDictionary(_ value: NSDictionary) -> ${modelName} {
+        return ${modelName}(${args})
+    }
+}`;
+    })
+    .filter(Boolean)
+    .join('\n\n');
+}
+
+function mapDictionaryValueToSwiftExpression(
+  fieldName: string,
+  fieldType: string
+): string {
+  const valueAccess = `value["${fieldName}"]`;
+  if (fieldType === 'string') {
+    return `${valueAccess} as! String`;
+  }
+  if (fieldType === 'number') {
+    return `(${valueAccess} as! NSNumber).doubleValue`;
+  }
+  if (fieldType === 'boolean') {
+    return `(${valueAccess} as! NSNumber).boolValue`;
+  }
+  return `${fieldType}.fromDictionary(${valueAccess} as! NSDictionary)`;
+}
+
+function generateKotlinModelConversionExtensions(
+  modelDefinitions: ModelDefinition[],
+  modelTypeNames: string[]
+): string {
+  const modelDefinitionsByName = new Map(
+    modelDefinitions.map((definition) => [definition.name, definition])
+  );
+
+  return modelTypeNames
+    .map((modelName) => {
+      const definition = modelDefinitionsByName.get(modelName);
+      if (!definition) {
+        return '';
+      }
+
+      const sortedFields = [...definition.fields].sort((a, b) =>
+        a.name.localeCompare(b.name)
+      );
+      if (sortedFields.length === 0) {
+        return '';
+      }
+
+      const args = sortedFields
+        .map(
+          (field) =>
+            `${field.name} = ${mapReadableMapFieldExpression('value', field.name, field.type)}`
+        )
+        .join(', ');
+
+      return `fun to${modelName}(value: ReadableMap): ${modelName} {
+    return ${modelName}(${args})
+}`;
+    })
+    .filter(Boolean)
+    .join('\n\n');
+}
+
+function mapReadableMapFieldExpression(
+  mapName: string,
+  fieldName: string,
+  fieldType: string
+): string {
+  if (fieldType === 'string') {
+    return `${mapName}.getString("${fieldName}")!!`;
+  }
+  if (fieldType === 'number') {
+    return `${mapName}.getDouble("${fieldName}")`;
+  }
+  if (fieldType === 'boolean') {
+    return `${mapName}.getBoolean("${fieldName}")`;
+  }
+  return `to${fieldType}(${mapName}.getMap("${fieldName}")!!)`;
 }

--- a/packages/cli/src/navigation/generators/ts.ts
+++ b/packages/cli/src/navigation/generators/ts.ts
@@ -1,21 +1,52 @@
 import path from 'node:path';
 import { createRequire } from 'node:module';
 
-import type { MethodSignature } from '../types.js';
+import type { MethodSignature, TypeDeclaration } from '../types.js';
 
-export function generateTurboModuleSpec(methods: MethodSignature[]): string {
+interface TurboSpecGenerationOptions {
+  modelTypeNames?: string[];
+}
+
+function mapTypeForTurboSpec(
+  typeText: string,
+  options: TurboSpecGenerationOptions
+): string {
+  if (typeText.startsWith('Promise<')) {
+    const inner = typeText.slice(8, -1);
+    return `Promise<${mapTypeForTurboSpec(inner, options)}>`;
+  }
+
+  if (options.modelTypeNames?.includes(typeText)) {
+    return 'Object';
+  }
+
+  return typeText;
+}
+
+export function generateTurboModuleSpec(
+  methods: MethodSignature[],
+  referencedTypeDeclarations: TypeDeclaration[] = [],
+  options: TurboSpecGenerationOptions = {}
+): string {
   const methodSignatures = methods
     .map((method) => {
       const params = method.params
-        .map((param) => `${param.name}${param.optional ? '?' : ''}: ${param.type}`)
+        .map(
+          (param) =>
+            `${param.name}${param.optional ? '?' : ''}: ${mapTypeForTurboSpec(param.type, options)}`
+        )
         .join(', ');
-      return `  ${method.name}(${params}): ${method.returnType};`;
+      return `  ${method.name}(${params}): ${mapTypeForTurboSpec(method.returnType, options)};`;
     })
     .join('\n');
+  const typeDeclarationsBlock =
+    referencedTypeDeclarations.length === 0
+      ? ''
+      : `${referencedTypeDeclarations.map((entry) => entry.declaration).join('\n\n')}\n\n`;
 
   return `import { TurboModuleRegistry, type TurboModule } from 'react-native';
 
-export interface Spec extends TurboModule {
+${typeDeclarationsBlock}export interface Spec extends TurboModule {
 ${methodSignatures}
 }
 
@@ -25,7 +56,22 @@ export default TurboModuleRegistry.getEnforcing<Spec>(
 `;
 }
 
-export function generateIndexTs(methods: MethodSignature[]): string {
+function buildTypeImportLine(
+  referencedTypeDeclarations: TypeDeclaration[]
+): string {
+  if (referencedTypeDeclarations.length === 0) {
+    return '';
+  }
+
+  const names = referencedTypeDeclarations.map((entry) => entry.name).join(', ');
+  return `import type { ${names} } from './NativeBrownfieldNavigation';\n`;
+}
+
+export function generateIndexTs(
+  methods: MethodSignature[],
+  referencedTypeDeclarations: TypeDeclaration[] = []
+): string {
+  const typeImportLine = buildTypeImportLine(referencedTypeDeclarations);
   const functionImplementations = methods
     .map((method) => {
       const params = method.params
@@ -47,6 +93,7 @@ export function generateIndexTs(methods: MethodSignature[]): string {
     .join(',\n');
 
   return `import NativeBrownfieldNavigation from './NativeBrownfieldNavigation';
+${typeImportLine}
 
 const BrownfieldNavigation = {
 ${functionImplementations},
@@ -104,7 +151,11 @@ export function transpileWithConsumerBabel(
   return transformed.code;
 }
 
-export function generateIndexDts(methods: MethodSignature[]): string {
+export function generateIndexDts(
+  methods: MethodSignature[],
+  referencedTypeDeclarations: TypeDeclaration[] = []
+): string {
+  const typeImportLine = buildTypeImportLine(referencedTypeDeclarations);
   const methodSignatures = methods
     .map((method) => {
       const params = method.params
@@ -114,7 +165,7 @@ export function generateIndexDts(methods: MethodSignature[]): string {
     })
     .join('\n');
 
-  return `declare const BrownfieldNavigation: {
+  return `${typeImportLine}declare const BrownfieldNavigation: {
 ${methodSignatures}
 };
 

--- a/packages/cli/src/navigation/parser.ts
+++ b/packages/cli/src/navigation/parser.ts
@@ -1,9 +1,48 @@
 import fs from 'node:fs';
 import { Project } from 'ts-morph';
 
-import type { MethodParam, MethodSignature } from './types.js';
+import type {
+  ModelDefinition,
+  ModelFieldDefinition,
+  MethodParam,
+  MethodSignature,
+  ParsedNavigationSpec,
+  TypeDeclaration,
+} from './types.js';
+import { Node } from 'ts-morph';
 
-export function parseNavigationSpec(specPath: string): MethodSignature[] {
+const SKIP_TYPE_TOKENS = new Set([
+  'Array',
+  'Date',
+  'Map',
+  'Object',
+  'Promise',
+  'ReadonlyArray',
+  'Record',
+  'Set',
+  'any',
+  'boolean',
+  'false',
+  'null',
+  'number',
+  'object',
+  'string',
+  'true',
+  'undefined',
+  'unknown',
+  'void',
+]);
+
+function collectReferencedTypesFromText(typeText: string): string[] {
+  const matches = typeText.match(/\b[A-Za-z_]\w*\b/g);
+  if (!matches) {
+    return [];
+  }
+
+  return matches.filter((match) => !SKIP_TYPE_TOKENS.has(match));
+}
+
+export function parseNavigationSpec(specPath: string): ParsedNavigationSpec {
   if (!fs.existsSync(specPath)) {
     throw new Error(`Spec file not found: ${specPath}`);
   }
@@ -20,7 +59,7 @@ export function parseNavigationSpec(specPath: string): MethodSignature[] {
     );
   }
 
-  return specInterface.getMethods().map((method): MethodSignature => {
+  const methods = specInterface.getMethods().map((method): MethodSignature => {
     const name = method.getName();
     const params: MethodParam[] = method.getParameters().map((param) => {
       const typeNode = param.getTypeNode();
@@ -40,4 +79,99 @@ export function parseNavigationSpec(specPath: string): MethodSignature[] {
       isAsync: returnType.startsWith('Promise<'),
     };
   });
+
+  const declarationNodes = [
+    ...sourceFile.getTypeAliases(),
+    ...sourceFile.getInterfaces(),
+  ].filter((node) => {
+    const nodeName = node.getName();
+    return nodeName !== 'BrownfieldNavigationSpec' && nodeName !== 'Spec';
+  });
+
+  const declarationByName = new Map<string, string>(
+    declarationNodes.map((node) => {
+      const declarationText = node.getText();
+      const normalizedDeclaration = node.isExported()
+        ? declarationText
+        : `export ${declarationText}`;
+      return [node.getName(), normalizedDeclaration];
+    })
+  );
+  const referencedTypeNames = new Set<string>();
+  for (const method of methods) {
+    for (const typeText of [
+      method.returnType,
+      ...method.params.map((param) => param.type),
+    ]) {
+      for (const typeName of collectReferencedTypesFromText(typeText)) {
+        referencedTypeNames.add(typeName);
+      }
+    }
+  }
+
+  const referencedTypeDeclarations: TypeDeclaration[] = [];
+  const modelDefinitions: ModelDefinition[] = [];
+  const addedTypeNames = new Set<string>();
+  const queue = [...referencedTypeNames];
+
+  while (queue.length > 0) {
+    const typeName = queue.shift();
+    if (!typeName || addedTypeNames.has(typeName)) {
+      continue;
+    }
+
+    const declaration = declarationByName.get(typeName);
+    if (!declaration) {
+      continue;
+    }
+
+    addedTypeNames.add(typeName);
+    referencedTypeDeclarations.push({ name: typeName, declaration });
+    const declarationNode = declarationNodes.find((node) => node.getName() === typeName);
+    if (declarationNode) {
+      const fields = extractModelFields(declarationNode);
+      if (fields.length > 0) {
+        modelDefinitions.push({ name: typeName, fields });
+      }
+    }
+
+    for (const nestedTypeName of collectReferencedTypesFromText(declaration)) {
+      if (
+        !addedTypeNames.has(nestedTypeName) &&
+        declarationByName.has(nestedTypeName)
+      ) {
+        queue.push(nestedTypeName);
+      }
+    }
+  }
+
+  return {
+    methods,
+    referencedTypeDeclarations,
+    modelDefinitions,
+  };
+}
+
+function extractModelFields(node: Node): ModelFieldDefinition[] {
+  if (Node.isInterfaceDeclaration(node)) {
+    return node.getProperties().map((property) => ({
+      name: property.getName(),
+      type: property.getTypeNode()?.getText() ?? 'unknown',
+      optional: property.hasQuestionToken(),
+    }));
+  }
+
+  if (Node.isTypeAliasDeclaration(node)) {
+    const typeNode = node.getTypeNode();
+    if (!typeNode || !Node.isTypeLiteral(typeNode)) {
+      return [];
+    }
+    return typeNode.getProperties().map((property) => ({
+      name: property.getName(),
+      type: property.getTypeNode()?.getText() ?? 'unknown',
+      optional: property.hasQuestionToken(),
+    }));
+  }
+
+  return [];
 }

--- a/packages/cli/src/navigation/runner.ts
+++ b/packages/cli/src/navigation/runner.ts
@@ -241,10 +241,16 @@ export async function runNavigationCodegen({
     indexTs,
     indexJs: transpileWithConsumerBabel(indexTs, projectRoot, packageRoot),
     indexDts: generateIndexDts(methods),
-    swiftDelegate: generateSwiftDelegate(methods),
+    swiftDelegate: generateSwiftDelegate(methods, {
+      modelTypeNames: models.modelTypeNames,
+    }),
     objcImplementation: generateObjCImplementation(methods),
-    kotlinDelegate: generateKotlinDelegate(methods, androidJavaPackageName),
-    kotlinModule: generateKotlinModule(methods, androidJavaPackageName),
+    kotlinDelegate: generateKotlinDelegate(methods, androidJavaPackageName, {
+      modelTypeNames: models.modelTypeNames,
+    }),
+    kotlinModule: generateKotlinModule(methods, androidJavaPackageName, {
+      modelTypeNames: models.modelTypeNames,
+    }),
   };
 
   if (models.modelTypeNames.length > 0) {

--- a/packages/cli/src/navigation/runner.ts
+++ b/packages/cli/src/navigation/runner.ts
@@ -218,7 +218,8 @@ export async function runNavigationCodegen({
   intro(`Running Brownfield Navigation codegen`);
 
   logger.info(`Parsing spec file: ${resolvedSpecPath}`);
-  const methods = parseNavigationSpec(resolvedSpecPath);
+  const { methods, referencedTypeDeclarations, modelDefinitions } =
+    parseNavigationSpec(resolvedSpecPath);
   if (methods.length === 0) {
     throw new Error('No methods found in spec file');
   }
@@ -229,22 +230,27 @@ export async function runNavigationCodegen({
 
   const packageRoot = getNavigationPackagePath(projectRoot);
   const androidJavaPackageName = DEFAULT_ANDROID_JAVA_PACKAGE;
-  const indexTs = generateIndexTs(methods);
+  const indexTs = generateIndexTs(methods, referencedTypeDeclarations);
   const models = await generateNavigationModels({
     specPath: resolvedSpecPath,
     methods,
     kotlinPackageName: androidJavaPackageName,
+    modelDefinitions,
   });
 
   const artifacts: GeneratedNavigationArtifacts = {
-    turboModuleSpec: generateTurboModuleSpec(methods),
+    turboModuleSpec: generateTurboModuleSpec(methods, referencedTypeDeclarations, {
+      modelTypeNames: models.modelTypeNames,
+    }),
     indexTs,
     indexJs: transpileWithConsumerBabel(indexTs, projectRoot, packageRoot),
-    indexDts: generateIndexDts(methods),
+    indexDts: generateIndexDts(methods, referencedTypeDeclarations),
     swiftDelegate: generateSwiftDelegate(methods, {
       modelTypeNames: models.modelTypeNames,
     }),
-    objcImplementation: generateObjCImplementation(methods),
+    objcImplementation: generateObjCImplementation(methods, {
+      modelTypeNames: models.modelTypeNames,
+    }),
     kotlinDelegate: generateKotlinDelegate(methods, androidJavaPackageName, {
       modelTypeNames: models.modelTypeNames,
     }),

--- a/packages/cli/src/navigation/types.ts
+++ b/packages/cli/src/navigation/types.ts
@@ -11,6 +11,28 @@ export interface MethodSignature {
   isAsync: boolean;
 }
 
+export interface TypeDeclaration {
+  name: string;
+  declaration: string;
+}
+
+export interface ModelFieldDefinition {
+  name: string;
+  type: string;
+  optional: boolean;
+}
+
+export interface ModelDefinition {
+  name: string;
+  fields: ModelFieldDefinition[];
+}
+
+export interface ParsedNavigationSpec {
+  methods: MethodSignature[];
+  referencedTypeDeclarations: TypeDeclaration[];
+  modelDefinitions: ModelDefinition[];
+}
+
 export interface GeneratedNavigationArtifacts {
   turboModuleSpec: string;
   indexTs: string;


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

Fixes #312 

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

Object types now correctly reflect in the `BrownfieldNavigationDelegate`:

Schema:

```ts
type UserType = {
  id: string;
  name: string;
  email: string;
};

export interface BrownfieldNavigationSpec {
  /**
   * Navigate to the native settings screen
   */
  navigateToSettings(user: UserType): void;

  /**
   * Navigate to the native referrals screen
   * @param userId - The user's unique identifier
   */
  navigateToReferrals(userId: string): void;
}
```

Kotlin:

```kt
interface BrownfieldNavigationDelegate {
  fun navigateToSettings(user: UserType)
  fun navigateToReferrals(userId: String)
}
```

Swift:

```swift
@objc public protocol BrownfieldNavigationDelegate: AnyObject {
    @objc func navigateToSettings(_ user: UserType)
    @objc func navigateToReferrals(_ userId: String)
}

```
