### PR TITLE
(fix): fix method to deallocate reactNativeFactory instance for expo

### DIFF
--- a/.changeset/silly-wolves-thank.md
+++ b/.changeset/silly-wolves-thank.md
@@ -1,0 +1,5 @@
+---
+'@callstack/react-native-brownfield': patch
+---
+
+fix: fix method to deallocate reactNativeFactory instance for expo

--- a/apps/AppleApp/Brownfield Apple App/components/ContentView.swift
+++ b/apps/AppleApp/Brownfield Apple App/components/ContentView.swift
@@ -33,13 +33,6 @@ struct ContentView: View {
                     .navigationBarHidden(true)
                     .clipShape(RoundedRectangle(cornerRadius: 16))
                     .background(Color(UIColor.systemBackground))
-                
-                Button("Stop React Native") {
-                    ReactNativeBrownfield.shared.stopReactNative()
-                }
-                    .buttonStyle(PlainButtonStyle())
-                    .padding(.top)
-                    .foregroundColor(.red)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .padding(16)

--- a/apps/AppleApp/Brownfield Apple App/components/GreetingCard.swift
+++ b/apps/AppleApp/Brownfield Apple App/components/GreetingCard.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import ReactBrownfield
 import Brownie
 
 struct GreetingCard: View {
@@ -17,10 +18,18 @@ struct GreetingCard: View {
            .multilineTextAlignment(.center)
            .font(.body)
 
-           Button("Increment counter") {
-               $counter.set { $0 + 1 }
+            
+           HStack {
+               Button("Increment counter") {
+                   $counter.set { $0 + 1 }
+               }
+               .buttonStyle(.borderedProminent)
+                
+                Button("Stop RN") {
+                    ReactNativeBrownfield.shared.stopReactNative()
+                }
+                .buttonStyle(.borderedProminent)
            }
-           .buttonStyle(.borderedProminent)
         }
     }
 }

--- a/packages/react-native-brownfield/ios/Expo/ExpoHostRuntime.swift
+++ b/packages/react-native-brownfield/ios/Expo/ExpoHostRuntime.swift
@@ -65,6 +65,9 @@ final class ExpoHostRuntime {
       return
     }
 
+    if let rootViewFactory = reactNativeFactory?.rootViewFactory {
+        (rootViewFactory as AnyObject).setValue(nil, forKey: "reactHost")
+    }
     reactNativeFactory = nil
     expoDelegate = nil
   }


### PR DESCRIPTION
### Summary

This PR breaks the strong reference-cycle by `nil`ing the `reactHost` instance from the view factory.

The location of the _Stop React Native_ has been changed, now it's in the top card. It changed its name too - to _Stop RN_.

<img width="1120" height="532" alt="Simulator Screenshot - iPhone 16e - 2026-05-22 at 11 05 08" src="https://github.com/user-attachments/assets/8e6fb4a9-fd55-4c46-beba-1448a7846072" />

### Test plan

1. Run Expo54/Expo55 app on iOS
2. Push the _Stop RN_ button
