### PR TITLE
feat(android): support bundled JS in debug builds

### DIFF
--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/plugin/RNSourceSets.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/plugin/RNSourceSets.kt
@@ -46,7 +46,12 @@ object RNSourceSets {
 
     private fun configureSourceSets() {
         project.extensions.getByType(LibraryExtension::class.java).libraryVariants.all { variant ->
-            val bundledAssetsVariantName = Utils.getBundledAssetsVariantName(variant)
+            val bundledAssetsVariantName =
+                Utils.getBundledAssetsVariantName(
+                    variantName = variant.name,
+                    buildTypeName = variant.buildType.name,
+                    isDebuggable = variant.buildType.isDebuggable,
+                )
             val capitalizedBundledAssetsVariantName = bundledAssetsVariantName.capitalized()
 
             androidExtension.sourceSets.getByName("main") { sourceSet ->

--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/plugin/RNSourceSets.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/plugin/RNSourceSets.kt
@@ -46,7 +46,8 @@ object RNSourceSets {
 
     private fun configureSourceSets() {
         project.extensions.getByType(LibraryExtension::class.java).libraryVariants.all { variant ->
-            val capitalizedVariantName = variant.name.capitalized()
+            val bundledAssetsVariantName = Utils.getBundledAssetsVariantName(variant)
+            val capitalizedBundledAssetsVariantName = bundledAssetsVariantName.capitalized()
 
             androidExtension.sourceSets.getByName("main") { sourceSet ->
                 sourceSet.java.srcDirs("$moduleBuildDir/generated/autolinking/src/main/java")
@@ -55,15 +56,16 @@ object RNSourceSets {
             androidExtension.sourceSets.getByName(variant.name) { sourceSet ->
                 for (bundlePathSegment in listOf(
                     // outputs for RN <= 0.81
-                    "createBundle${capitalizedVariantName}JsAndAssets",
+                    "createBundle${capitalizedBundledAssetsVariantName}JsAndAssets",
                     // outputs for RN >= 0.82
-                    "react/${variant.name}",
+                    "react/$bundledAssetsVariantName",
                 )) {
                     sourceSet.assets.srcDirs("$appBuildDir/generated/assets/$bundlePathSegment")
                     sourceSet.res.srcDirs("$appBuildDir/generated/res/$bundlePathSegment")
                 }
 
-                val expoUpdatesResources =  "create${capitalizedVariantName}UpdatesResources"
+                val expoUpdatesResources =
+                    "create${capitalizedBundledAssetsVariantName}UpdatesResources"
                 sourceSet.assets.srcDirs("$appBuildDir/generated/assets/$expoUpdatesResources")
             }
         }

--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/processors/VariantProcessor.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/processors/VariantProcessor.kt
@@ -58,21 +58,24 @@ class VariantProcessor(private val variant: LibraryVariant) : BaseProject() {
             throw TaskNotFound("Can not find $preBuildTaskPath task")
         }
 
-        val bundledAssetsVariantName = Utils.getBundledAssetsVariantName(variant)
+        val bundledAssetsVariantName =
+            Utils.getBundledAssetsVariantName(
+                variantName = variant.name,
+                buildTypeName = variant.buildType.name,
+                isDebuggable = variant.buildType.isDebuggable,
+            )
         val capitalizedBundledAssetsVariantName = bundledAssetsVariantName.capitalized()
 
-        if (bundledAssetsVariantName != variant.name || capitalizedVariantName.contains("Release")) {
-            val projectExt = project.extensions.getByType(Extension::class.java)
-            val appProject = project.rootProject.project(projectExt.appProjectName)
-            prepareTask.dependsOn(
-                "${appProject.path}:createBundle${capitalizedBundledAssetsVariantName}JsAndAssets",
-            )
+        val projectExt = project.extensions.getByType(Extension::class.java)
+        val appProject = project.rootProject.project(projectExt.appProjectName)
+        prepareTask.dependsOn(
+            "${appProject.path}:createBundle${capitalizedBundledAssetsVariantName}JsAndAssets",
+        )
 
-            if (Utils.isExpoProject(project)) {
-                prepareTask.dependsOn(
-                    "${appProject.path}:create${capitalizedBundledAssetsVariantName}UpdatesResources",
-                )
-            }
+        if (Utils.isExpoProject(project)) {
+            prepareTask.dependsOn(
+                "${appProject.path}:create${capitalizedBundledAssetsVariantName}UpdatesResources",
+            )
         }
 
         val bundleTask = variantTaskProvider.bundleTaskProvider(project, variant.name)

--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/processors/VariantProcessor.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/processors/VariantProcessor.kt
@@ -58,13 +58,20 @@ class VariantProcessor(private val variant: LibraryVariant) : BaseProject() {
             throw TaskNotFound("Can not find $preBuildTaskPath task")
         }
 
-        if (capitalizedVariantName.contains("Release")) {
+        val bundledAssetsVariantName = Utils.getBundledAssetsVariantName(variant)
+        val capitalizedBundledAssetsVariantName = bundledAssetsVariantName.capitalized()
+
+        if (bundledAssetsVariantName != variant.name || capitalizedVariantName.contains("Release")) {
             val projectExt = project.extensions.getByType(Extension::class.java)
             val appProject = project.rootProject.project(projectExt.appProjectName)
-            prepareTask.dependsOn("${appProject.path}:createBundle${capitalizedVariantName}JsAndAssets")
+            prepareTask.dependsOn(
+                "${appProject.path}:createBundle${capitalizedBundledAssetsVariantName}JsAndAssets",
+            )
 
             if (Utils.isExpoProject(project)) {
-                prepareTask.dependsOn("${appProject.path}:create${capitalizedVariantName}UpdatesResources")
+                prepareTask.dependsOn(
+                    "${appProject.path}:create${capitalizedBundledAssetsVariantName}UpdatesResources",
+                )
             }
         }
 

--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/utils/Utils.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/utils/Utils.kt
@@ -1,6 +1,5 @@
 package com.callstack.react.brownfield.utils
 
-import com.android.build.gradle.api.LibraryVariant
 import com.callstack.react.brownfield.plugin.RNBrownfieldPlugin.Companion.EXPO_PROJECT_LOCATOR
 import org.gradle.api.Project
 import java.io.File
@@ -48,19 +47,22 @@ object Utils {
         return project.findProject(EXPO_PROJECT_LOCATOR) != null
     }
 
-    fun getBundledAssetsVariantName(variant: LibraryVariant): String {
-        if (!variant.buildType.isDebuggable) {
-            return variant.name
+    fun getBundledAssetsVariantName(
+        variantName: String,
+        buildTypeName: String,
+        isDebuggable: Boolean,
+    ): String {
+        if (!isDebuggable) {
+            return variantName
         }
 
-        val buildTypeName = variant.buildType.name
-        if (variant.name == buildTypeName) {
+        if (variantName == buildTypeName) {
             return "release"
         }
 
         val capitalizedBuildTypeName = buildTypeName.capitalized()
-        return if (variant.name.endsWith(capitalizedBuildTypeName)) {
-            "${variant.name.removeSuffix(capitalizedBuildTypeName)}Release"
+        return if (variantName.endsWith(capitalizedBuildTypeName)) {
+            "${variantName.removeSuffix(capitalizedBuildTypeName)}Release"
         } else {
             "release"
         }

--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/utils/Utils.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/utils/Utils.kt
@@ -1,5 +1,6 @@
 package com.callstack.react.brownfield.utils
 
+import com.android.build.gradle.api.LibraryVariant
 import com.callstack.react.brownfield.plugin.RNBrownfieldPlugin.Companion.EXPO_PROJECT_LOCATOR
 import org.gradle.api.Project
 import java.io.File
@@ -45,5 +46,23 @@ object Utils {
 
     fun isExpoProject(project: Project): Boolean {
         return project.findProject(EXPO_PROJECT_LOCATOR) != null
+    }
+
+    fun getBundledAssetsVariantName(variant: LibraryVariant): String {
+        if (!variant.buildType.isDebuggable) {
+            return variant.name
+        }
+
+        val buildTypeName = variant.buildType.name
+        if (variant.name == buildTypeName) {
+            return "release"
+        }
+
+        val capitalizedBuildTypeName = buildTypeName.capitalized()
+        return if (variant.name.endsWith(capitalizedBuildTypeName)) {
+            "${variant.name.removeSuffix(capitalizedBuildTypeName)}Release"
+        } else {
+            "release"
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes Android debug AAR packaging so a clean `brownfield package:android --variant debug` build embeds the JavaScript bundle instead of depending on stale outputs from a prior release build.

## Root cause

Android debug packaging was not deterministic from a clean build.

The brownfield plugin correctly guarded React Native bundling so it only ran for release variants, but debug AAR assembly still expected the generated JS/assets to already exist. In practice this meant debug packaging only appeared to work when a previous release build had already left `index.android.bundle` behind.

## What changed

- maps debuggable variants to their sibling release bundle-producing variant
  - `debug -> release`
  - flavored variants like `freeDebug -> freeRelease`
- updates Android source-set wiring so debug library variants read bundled assets and resources from the mapped release outputs
- updates variant pre-build dependencies so clean debug packaging explicitly runs the mapped release JS bundle task before AAR assembly
- keeps the existing release-only bundling rule intact instead of introducing a new Android runtime API

## Validation

- republished the local brownfield Gradle plugin snapshot with `yarn brownfield:plugin:publish:local`
- ran a clean package build:
  - `cd apps/RNApp/android && ./gradlew -p BrownfieldLib clean`
  - `cd apps/RNApp && yarn exec brownfield package:android --module-name :BrownfieldLib --variant debug`
- confirmed the clean debug run now invokes `:app:createBundleReleaseJsAndAssets`
- confirmed the produced debug AAR now contains `assets/index.android.bundle`

## Impact

Debug AARs built from a clean checkout are now self-sufficient at the packaging layer. This removes the accidental dependency on a prior release build and is the prerequisite for running Android brownfield consumers without Metro in debug packaging flows.
