### PR TITLE
fix: call copyStrippedSoLibs once after the loop to avoid redundant SO file copying

### DIFF
--- a/.changeset/grumpy-jars-see.md
+++ b/.changeset/grumpy-jars-see.md
@@ -1,0 +1,5 @@
+---
+'brownfield': patch
+---
+
+fix: call copyStrippedSoLibs once after the loop to avoid redundant SO file copying

--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/processors/JNILibsProcessor.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/processors/JNILibsProcessor.kt
@@ -53,9 +53,7 @@ class JNILibsProcessor : BaseProject() {
                 for (archiveLibrary in aarLibraries) {
                     val jniDir = archiveLibrary.getJniDir()
                     processNestedLibs(jniDir.listFiles(), existingJNILibs)
-                    if (projectExt.useStrippedSoFiles) {
-                        copyStrippedSoLibs(variant, existingJNILibs)
-                    } else {
+                    if (!projectExt.useStrippedSoFiles) {
                         if (jniDir.exists()) {
                             val filteredSourceSets =
                                 androidExtension.sourceSets.filter { sourceSet -> sourceSet.name == variant.name }
@@ -66,6 +64,9 @@ class JNILibsProcessor : BaseProject() {
                             }
                         }
                     }
+                }
+                if (projectExt.useStrippedSoFiles) {
+                    copyStrippedSoLibs(variant, existingJNILibs)
                 }
             }
         }


### PR DESCRIPTION
### Summary

Optimize SO stripping by calling `copyStrippedSoLibs` once after the loop.