### PR TITLE
fix: make EXUpdates as a dependency only when installed

### DIFF
--- a/.changeset/shaky-meals-ring.md
+++ b/.changeset/shaky-meals-ring.md
@@ -1,0 +1,5 @@
+---
+'@callstack/react-native-brownfield': patch
+---
+
+make EXUpdates as a dependency only when installed

--- a/packages/react-native-brownfield/ReactBrownfield.podspec
+++ b/packages/react-native-brownfield/ReactBrownfield.podspec
@@ -3,11 +3,15 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 expo_updates_installed = lambda do
-  install_root = Pod::Config.instance.installation_root.to_s
+  Pod::Executable.execute_command('node', [
+    '-p',
+    'require.resolve("expo-updates/package.json", { paths: [process.argv[1]] })',
+    Pod::Config.instance.installation_root.to_s,
+  ]).strip
 
-  File.exist?(
-    File.join(install_root, 'node_modules', 'expo-updates', 'package.json')
-  )
+  true
+rescue
+  false
 end
 
 Pod::Spec.new do |spec|

--- a/packages/react-native-brownfield/ReactBrownfield.podspec
+++ b/packages/react-native-brownfield/ReactBrownfield.podspec
@@ -2,6 +2,14 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
+expo_updates_installed = lambda do
+  install_root = Pod::Config.instance.installation_root.to_s
+
+  File.exist?(
+    File.join(install_root, 'node_modules', 'expo-updates', 'package.json')
+  )
+end
+
 Pod::Spec.new do |spec|
   spec.name         = "ReactBrownfield"
   spec.version      = package['version']
@@ -33,7 +41,7 @@ Pod::Spec.new do |spec|
 
   if ENV['REACT_NATIVE_BROWNFIELD_USE_EXPO_HOST'] == '1'
     spec.dependency 'Expo'
-    spec.dependency 'EXUpdates'
+    spec.dependency 'EXUpdates' if expo_updates_installed.call
   end
 
   install_modules_dependencies(spec)

--- a/packages/react-native-brownfield/ReactBrownfield.podspec
+++ b/packages/react-native-brownfield/ReactBrownfield.podspec
@@ -7,7 +7,7 @@ expo_updates_installed = lambda do
     '-p',
     'require.resolve("expo-updates/package.json", { paths: [process.argv[1]] })',
     Pod::Config.instance.installation_root.to_s,
-  ]).strip
+  ])
 
   true
 rescue


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

This PR fixes the issue where `expo-updates` are added as dependency in Podspec of `react-native-brownfield` if the project is Expo. However, even Expo projects may not use `expo-updates`.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

- Verified Locally on a new Expo App without `expo-updates`
- CI Passes
