### PR TITLE
fix: keep only one reference of xcframeworks when spm enabled

### DIFF
--- a/.changeset/gold-loops-live.md
+++ b/.changeset/gold-loops-live.md
@@ -1,0 +1,5 @@
+---
+'@callstack/brownfield-cli': minor
+---
+
+keep only one reference of xcframeworks when spm enabled

--- a/packages/cli/src/brownfield/utils/__tests__/createLocalSpmPackage.test.ts
+++ b/packages/cli/src/brownfield/utils/__tests__/createLocalSpmPackage.test.ts
@@ -59,7 +59,7 @@ describe('createLocalSpmPackage', () => {
     ).toBe(true);
     expect(
       fs.existsSync(path.join(tempDir, 'BrownfieldLib.xcframework'))
-    ).toBe(true);
+    ).toBe(false);
 
     const readmePath = path.join(tempDir, 'README.md');
     expect(fs.existsSync(readmePath)).toBe(true);

--- a/packages/cli/src/brownfield/utils/__tests__/prepareLocalSpmArtifacts.test.ts
+++ b/packages/cli/src/brownfield/utils/__tests__/prepareLocalSpmArtifacts.test.ts
@@ -46,7 +46,7 @@ describe('prepareLocalSpmArtifacts', () => {
     fs.rmSync(tempDir, { recursive: true, force: true });
   });
 
-  it('copies xcframeworks into spm-artifacts and removes embedded code signature data', () => {
+  it('moves xcframeworks into spm-artifacts and removes embedded code signature data', () => {
     createSignedMockXcframework(tempDir, 'React');
 
     const spmArtifactsDir = prepareLocalSpmArtifacts({
@@ -82,28 +82,7 @@ describe('prepareLocalSpmArtifacts', () => {
       ['--remove-signature', path.join(copiedFrameworkDir, 'React')],
       expect.objectContaining({ stdio: 'pipe' })
     );
-    expect(
-      fs.existsSync(
-        path.join(
-          tempDir,
-          'React.xcframework',
-          '_CodeSignature',
-          'CodeResources'
-        )
-      )
-    ).toBe(true);
-    expect(
-      fs.existsSync(
-        path.join(
-          tempDir,
-          'React.xcframework',
-          'ios-arm64_x86_64-simulator',
-          'React.framework',
-          '_CodeSignature',
-          'CodeResources'
-        )
-      )
-    ).toBe(true);
+    expect(fs.existsSync(path.join(tempDir, 'React.xcframework'))).toBe(false);
   });
 
   it('ignores remove-signature errors for unsigned binaries', () => {

--- a/packages/cli/src/brownfield/utils/createLocalSpmPackage.ts
+++ b/packages/cli/src/brownfield/utils/createLocalSpmPackage.ts
@@ -148,7 +148,7 @@ ${frameworks}
 
 1. In Xcode, choose **File > Add Package Dependencies...**
 2. Click **Add Local...**
-3. Select this folder, the one containing both \`Package.swift\` and the \`*.xcframework\` artifacts
+3. Select this folder, the one containing \`Package.swift\` and the \`spm-artifacts\` directory
 4. Add the \`${libraryName}\` library product to your app target
 
 ## Troubleshooting

--- a/packages/cli/src/brownfield/utils/prepareLocalSpmArtifacts.ts
+++ b/packages/cli/src/brownfield/utils/prepareLocalSpmArtifacts.ts
@@ -109,7 +109,7 @@ export function prepareLocalSpmArtifacts({
     const sourcePath = path.join(packageDir, `${targetName}.xcframework`);
     const destinationPath = path.join(spmArtifactsDir, `${targetName}.xcframework`);
 
-    fs.cpSync(sourcePath, destinationPath, { recursive: true });
+    fs.renameSync(sourcePath, destinationPath);
     normalizeCopiedXcframeworkSignature(destinationPath);
   }
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

This fixes the duplicate xcframeworks being generated when `--add-spm-package` is enabled. With this option, we see one instance of xcframeworks under `spm-artifacts` and other under `package/build`.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

Before:

<img width="326" height="403" alt="before" src="https://github.com/user-attachments/assets/2c787a50-ec9e-4649-ac23-e25abf95e289" />


After:

<img width="276" height="285" alt="after" src="https://github.com/user-attachments/assets/01327938-d1a7-4b73-94c4-b0da436832bc" />
