### PR TITLE
chore: add scm and developers field to brownfield-gradle-plugin

### DIFF
--- a/gradle-plugins/react/brownfield/build.gradle.kts
+++ b/gradle-plugins/react/brownfield/build.gradle.kts
@@ -66,6 +66,19 @@ publishing {
                         distribution.set("repo")
                     }
                 }
+
+                developers {
+                    developer {
+                        id.set("callstack")
+                        name.set("Callstack Team")
+                        email.set("it-admin@callstack.com")
+                    }
+                }
+                scm {
+                    connection.set(property("SCM_CONNECTION").toString())
+                    developerConnection.set(property("SCM_DEV_CONNECTION").toString())
+                    url.set(property("GITHUB_URL").toString())
+                }
             }
         }
     }


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

This adds back the SCM and Developers field to `brownfield-gradle-plugin/build.gradle`

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
