### PR TITLE
fix: use Expo canary and install generated beta app deps

### DIFF
--- a/.github/workflows/expo-beta-road-test.yml
+++ b/.github/workflows/expo-beta-road-test.yml
@@ -75,6 +75,7 @@ jobs:
       - name: Install Expo beta dependencies
         run: |
           cd apps/ExpoAppBeta
+          npm install
           npx expo install --fix
 
       - name: Run ExpoAppBeta -> AndroidApp road test
@@ -99,6 +100,7 @@ jobs:
       - name: Install Expo beta dependencies
         run: |
           cd apps/ExpoAppBeta
+          npm install
           npx expo install --fix
 
       - name: Run ExpoAppBeta -> AppleApp road test

--- a/.github/workflows/expo-beta-road-test.yml
+++ b/.github/workflows/expo-beta-road-test.yml
@@ -75,6 +75,7 @@ jobs:
       - name: Install Expo beta dependencies
         run: |
           cd apps/ExpoAppBeta
+          corepack enable
           yarn install
           npx expo install --fix
 
@@ -100,6 +101,7 @@ jobs:
       - name: Install Expo beta dependencies
         run: |
           cd apps/ExpoAppBeta
+          corepack enable
           yarn install
           npx expo install --fix
 

--- a/.github/workflows/expo-beta-road-test.yml
+++ b/.github/workflows/expo-beta-road-test.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Install Expo beta dependencies
         run: |
           cd apps/ExpoAppBeta
-          npm install
+          yarn install
           npx expo install --fix
 
       - name: Run ExpoAppBeta -> AndroidApp road test
@@ -100,7 +100,7 @@ jobs:
       - name: Install Expo beta dependencies
         run: |
           cd apps/ExpoAppBeta
-          npm install
+          yarn install
           npx expo install --fix
 
       - name: Run ExpoAppBeta -> AppleApp road test

--- a/apps/brownfield-example-shared-tests/e2e/appleAppDetoxUtils.cjs
+++ b/apps/brownfield-example-shared-tests/e2e/appleAppDetoxUtils.cjs
@@ -74,24 +74,43 @@ async function waitForAppleAppReadyVanilla() {
 async function waitForAppleAppReadyExpo() {
   const homeTab = by.label('Home');
   const homeElement = () => element(homeTab).atIndex(0);
+  const welcomeTitle = by.text(/Welcome to\s+Expo\s+55/);
   try {
     await waitForVisibleIgnoringSync(homeTab, 30000, 0);
+    return;
   } catch {
     // Some CI runs start with an unmounted RN surface; one reload usually recovers.
-    await device.reloadReactNative();
-    try {
-      await waitForVisibleIgnoringSync(homeTab, 30000, 0);
-      return;
-    } catch {
-      // Embedded RN may be off-screen in the native scroll view.
+  }
+
+  await device.reloadReactNative();
+  try {
+    await waitForVisibleIgnoringSync(homeTab, 30000, 0);
+    return;
+  } catch {
+    // Embedded RN may be off-screen in the native scroll view.
+  }
+
+  await device.disableSynchronization();
+  try {
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      try {
+        await scrollToEmbeddedRnExpo();
+      } catch {}
+
+      try {
+        await waitFor(homeElement()).toBeVisible().withTimeout(10000);
+        return;
+      } catch {}
+
+      try {
+        await waitFor(element(welcomeTitle)).toBeVisible().withTimeout(10000);
+        return;
+      } catch {}
     }
-    await device.disableSynchronization();
-    try {
-      await scrollToEmbeddedRnExpo();
-      await waitFor(homeElement()).toBeVisible().withTimeout(20000);
-    } finally {
-      await device.enableSynchronization();
-    }
+
+    await waitFor(homeElement()).toBeVisible().withTimeout(10000);
+  } finally {
+    await device.enableSynchronization();
   }
 }
 

--- a/scripts/check-expo-beta.ts
+++ b/scripts/check-expo-beta.ts
@@ -118,22 +118,16 @@ function getExpoTemplateAppDir(): string {
 
 function replaceTemplateAppReferences(contents: string): string {
   return contents
-    .replaceAll('@callstack/brownfield-example-expo-app-56', '@callstack/brownfield-example-expo-app-beta')
-    .replaceAll('@callstack/brownfield-example-expo-app-55', '@callstack/brownfield-example-expo-app-beta')
+    .replace(/@callstack\/brownfield-example-expo-app-\d+/g, '@callstack/brownfield-example-expo-app-beta')
     .replaceAll('"@callstack/brownfield-navigation": "workspace:^"', '"@callstack/brownfield-navigation": "file:../../packages/brownfield-navigation"')
     .replaceAll('"@callstack/brownie": "workspace:^"', '"@callstack/brownie": "file:../../packages/brownie"')
     .replaceAll('"@callstack/react-native-brownfield": "workspace:^"', '"@callstack/react-native-brownfield": "file:../../packages/react-native-brownfield"')
     .replaceAll('"@callstack/brownfield-example-shared-tests": "workspace:^"', '"@callstack/brownfield-example-shared-tests": "file:../brownfield-example-shared-tests"')
-    .replaceAll('com.callstack.rnbrownfield.demo.expoapp56', 'com.callstack.rnbrownfield.demo.expobeta')
-    .replaceAll('com.callstack.rnbrownfield.demo.expoapp55', 'com.callstack.rnbrownfield.demo.expobeta')
-    .replaceAll('./android/brownfieldlib/src/main/java/com/callstack/rnbrownfield/demo/expoapp56/Generated/', './android/brownfieldlib/src/main/java/com/callstack/rnbrownfield/demo/expobeta/Generated/')
-    .replaceAll('./android/brownfieldlib/src/main/java/com/callstack/rnbrownfield/demo/expoapp55/Generated/', './android/brownfieldlib/src/main/java/com/callstack/rnbrownfield/demo/expobeta/Generated/')
-    .replaceAll('ExpoApp56', 'ExpoAppBeta')
-    .replaceAll('ExpoApp55', 'ExpoAppBeta')
-    .replaceAll('expoapp56', 'expoappbeta')
-    .replaceAll('expoapp55', 'expoappbeta')
-    .replaceAll('expoappbeta56', 'expoappbeta')
-    .replaceAll('expoappbeta55', 'expoappbeta');
+    .replace(/com\.callstack\.rnbrownfield\.demo\.expoapp\d+/g, 'com.callstack.rnbrownfield.demo.expobeta')
+    .replace(/\.\/android\/brownfieldlib\/src\/main\/java\/com\/callstack\/rnbrownfield\/demo\/expoapp\d+\/Generated\//g, './android/brownfieldlib/src/main/java/com/callstack/rnbrownfield/demo/expobeta/Generated/')
+    .replace(/ExpoApp\d+/g, 'ExpoAppBeta')
+    .replace(/expoapp\d+/g, 'expoappbeta')
+    .replace(/expoappbeta\d+/g, 'expoappbeta');
 }
 
 function generateExpoBetaApp(): void {

--- a/scripts/check-expo-beta.ts
+++ b/scripts/check-expo-beta.ts
@@ -118,16 +118,18 @@ function getExpoTemplateAppDir(): string {
 
 function replaceTemplateAppReferences(contents: string): string {
   return contents
-    .replace(/@callstack\/brownfield-example-expo-app-\d+/g, '@callstack/brownfield-example-expo-app-beta')
-    .replaceAll('"@callstack/brownfield-navigation": "workspace:^"', '"@callstack/brownfield-navigation": "file:../../packages/brownfield-navigation"')
-    .replaceAll('"@callstack/brownie": "workspace:^"', '"@callstack/brownie": "file:../../packages/brownie"')
-    .replaceAll('"@callstack/react-native-brownfield": "workspace:^"', '"@callstack/react-native-brownfield": "file:../../packages/react-native-brownfield"')
-    .replaceAll('"@callstack/brownfield-example-shared-tests": "workspace:^"', '"@callstack/brownfield-example-shared-tests": "file:../brownfield-example-shared-tests"')
-    .replace(/com\.callstack\.rnbrownfield\.demo\.expoapp\d+/g, 'com.callstack.rnbrownfield.demo.expobeta')
-    .replace(/\.\/android\/brownfieldlib\/src\/main\/java\/com\/callstack\/rnbrownfield\/demo\/expoapp\d+\/Generated\//g, './android/brownfieldlib/src/main/java/com/callstack/rnbrownfield/demo/expobeta/Generated/')
-    .replace(/ExpoApp\d+/g, 'ExpoAppBeta')
-    .replace(/expoapp\d+/g, 'expoappbeta')
-    .replace(/expoappbeta\d+/g, 'expoappbeta');
+    .replaceAll('@callstack/brownfield-example-expo-app-56', '@callstack/brownfield-example-expo-app-beta')
+    .replaceAll('@callstack/brownfield-example-expo-app-55', '@callstack/brownfield-example-expo-app-beta')
+    .replaceAll('com.callstack.rnbrownfield.demo.expoapp56', 'com.callstack.rnbrownfield.demo.expobeta')
+    .replaceAll('com.callstack.rnbrownfield.demo.expoapp55', 'com.callstack.rnbrownfield.demo.expobeta')
+    .replaceAll('./android/brownfieldlib/src/main/java/com/callstack/rnbrownfield/demo/expoapp56/Generated/', './android/brownfieldlib/src/main/java/com/callstack/rnbrownfield/demo/expobeta/Generated/')
+    .replaceAll('./android/brownfieldlib/src/main/java/com/callstack/rnbrownfield/demo/expoapp55/Generated/', './android/brownfieldlib/src/main/java/com/callstack/rnbrownfield/demo/expobeta/Generated/')
+    .replaceAll('ExpoApp56', 'ExpoAppBeta')
+    .replaceAll('ExpoApp55', 'ExpoAppBeta')
+    .replaceAll('expoapp56', 'expoappbeta')
+    .replaceAll('expoapp55', 'expoappbeta')
+    .replaceAll('expoappbeta56', 'expoappbeta')
+    .replaceAll('expoappbeta55', 'expoappbeta');
 }
 
 function generateExpoBetaApp(): void {

--- a/scripts/check-expo-beta.ts
+++ b/scripts/check-expo-beta.ts
@@ -26,7 +26,6 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const REPO_ROOT = path.resolve(__dirname, '..');
 const EXPO_BETA_APP_DIR = path.join(REPO_ROOT, 'apps', 'ExpoAppBeta');
-const EXPO_TEMPLATE_APP_CANDIDATES = ['ExpoApp56', 'ExpoApp55'];
 const EXPO_BETA_PACKAGE_JSON_PATH = path.join(EXPO_BETA_APP_DIR, 'package.json');
 const EXPO_BETA_APP_JSON_PATH = path.join(EXPO_BETA_APP_DIR, 'app.json');
 const EXPO_NPM_REGISTRY_URL = 'https://registry.npmjs.org/expo';
@@ -69,7 +68,7 @@ function parseArgs(argv: string[]): CliOptions {
   return options;
 }
 
-export async function fetchLatestExpoBetaVersion(): Promise<string | null> {
+export async function fetchLatestExpoCanaryVersion(): Promise<string | null> {
   const response = await fetch(EXPO_NPM_REGISTRY_URL);
 
   if (!response.ok) {
@@ -81,13 +80,13 @@ export async function fetchLatestExpoBetaVersion(): Promise<string | null> {
     versions?: Record<string, unknown>;
   };
 
-  const betaTag = data['dist-tags']?.beta;
-  if (betaTag) {
-    return betaTag;
+  const canaryTag = data['dist-tags']?.canary;
+  if (canaryTag) {
+    return canaryTag;
   }
 
   const versions = Object.keys(data.versions ?? {})
-    .filter((version) => version.includes('beta'))
+    .filter((version) => version.includes('canary'))
     .sort((left, right) => left.localeCompare(right, undefined, { numeric: true }));
 
   return versions.at(-1) ?? null;
@@ -99,20 +98,32 @@ function updateFileContents(filePath: string, updater: (contents: string) => str
 }
 
 function getExpoTemplateAppDir(): string {
-  for (const candidate of EXPO_TEMPLATE_APP_CANDIDATES) {
-    const candidatePath = path.join(REPO_ROOT, 'apps', candidate);
-    if (existsSync(candidatePath)) {
-      return candidatePath;
-    }
+  const appsDir = path.join(REPO_ROOT, 'apps');
+  const expoAppCandidates = fs
+    .readdirSync(appsDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && /^ExpoApp\d+$/.test(entry.name))
+    .map((entry) => ({
+      path: path.join(appsDir, entry.name),
+      version: Number(entry.name.replace('ExpoApp', '')),
+    }))
+    .sort((left, right) => right.version - left.version);
+
+  const latestCandidate = expoAppCandidates[0];
+  if (!latestCandidate) {
+    throw new Error('Could not find an Expo template app directory');
   }
 
-  throw new Error('Could not find an Expo template app directory');
+  return latestCandidate.path;
 }
 
 function replaceTemplateAppReferences(contents: string): string {
   return contents
     .replaceAll('@callstack/brownfield-example-expo-app-56', '@callstack/brownfield-example-expo-app-beta')
     .replaceAll('@callstack/brownfield-example-expo-app-55', '@callstack/brownfield-example-expo-app-beta')
+    .replaceAll('"@callstack/brownfield-navigation": "workspace:^"', '"@callstack/brownfield-navigation": "file:../../packages/brownfield-navigation"')
+    .replaceAll('"@callstack/brownie": "workspace:^"', '"@callstack/brownie": "file:../../packages/brownie"')
+    .replaceAll('"@callstack/react-native-brownfield": "workspace:^"', '"@callstack/react-native-brownfield": "file:../../packages/react-native-brownfield"')
+    .replaceAll('"@callstack/brownfield-example-shared-tests": "workspace:^"', '"@callstack/brownfield-example-shared-tests": "file:../brownfield-example-shared-tests"')
     .replaceAll('com.callstack.rnbrownfield.demo.expoapp56', 'com.callstack.rnbrownfield.demo.expobeta')
     .replaceAll('com.callstack.rnbrownfield.demo.expoapp55', 'com.callstack.rnbrownfield.demo.expobeta')
     .replaceAll('./android/brownfieldlib/src/main/java/com/callstack/rnbrownfield/demo/expoapp56/Generated/', './android/brownfieldlib/src/main/java/com/callstack/rnbrownfield/demo/expobeta/Generated/')
@@ -217,7 +228,7 @@ function appendSummary(
 
 async function main(): Promise<void> {
   const options = parseArgs(process.argv.slice(2));
-  const latestVersion = options.expoVersion ?? (await fetchLatestExpoBetaVersion());
+  const latestVersion = options.expoVersion ?? (await fetchLatestExpoCanaryVersion());
 
   if (!latestVersion) {
     appendKeyValueFile(options.githubOutput, {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
Fixes the Expo beta follow-up issues in the CI workflow.

 Updates the Expo prerelease detection to use canary instead of the old beta channel, makes the generated ExpoAppBeta installable as a standalone temporary app in CI by rewriting workspace dependencies to local file: dependencies, and installs the Expo-required Android NDK in the Android CI environment. Also keeps the generated app intact through the iOS road test flow.
### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

- Run yarn lint
- Run yarn typecheck
- Trigger the Expo beta road test workflow manually
- Verify the workflow detects the latest Expo canary release
- Verify ExpoAppBeta installs correctly, expo install --fix runs, and the Android/iOS road tests 