### PR TITLE
fix: errors in CI, turbo config for navigation package, ENOSPC in CI, upload Detox recordings

### DIFF
--- a/.github/actions/androidapp-road-test/action.yml
+++ b/.github/actions/androidapp-road-test/action.yml
@@ -29,17 +29,8 @@ runs:
 
     - name: Prepare Android environment
       uses: ./.github/actions/prepare-android
-
-    - name: Restore Gradle cache
-      uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5
       with:
-        path: |
-          ~/.gradle/caches
-          ~/.gradle/wrapper
-        key: ${{ runner.os }}-android-androidapp-${{ inputs.flavor }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-        restore-keys: |
-          ${{ runner.os }}-android-androidapp-${{ inputs.flavor }}-gradle-
-          ${{ runner.os }}-android-androidapp-gradle-
+        gradle-workflow-job-context: ${{ inputs.flavor }}
 
     # == Brownfield Gradle Plugin ==
     - name: Publish Brownfield Gradle Plugin to Maven Local

--- a/.github/actions/androidapp-road-test/action.yml
+++ b/.github/actions/androidapp-road-test/action.yml
@@ -82,6 +82,18 @@ runs:
       run: stat ~/.m2/repository/${{ inputs.rn-project-maven-path }}/0.0.1-SNAPSHOT/brownfieldlib-0.0.1-SNAPSHOT-release.aar
       shell: bash
 
+    # clean up build artifacts to ensure no ENOSPC
+    - name: Clean up local build artifacts
+      run: |
+        rm -rf ${{ inputs.rn-project-path }}/android/build
+        rm -rf ${{ inputs.rn-project-path }}/android/.cxx
+        rm -rf ${{ inputs.rn-project-path }}/android/.gradle
+        rm -rf ${{ inputs.rn-project-path }}/android/app/build
+        rm -rf ${{ inputs.rn-project-path }}/android/app/.cxx
+        rm -rf ${{ inputs.rn-project-path }}/android/app/.gradle
+        rm -rf ${{ inputs.rn-project-path }}/android/app/build
+      shell: bash
+
     # == AndroidApp ==
 
     - name: Build native Android Brownfield app

--- a/.github/actions/appleapp-road-test/action.yml
+++ b/.github/actions/appleapp-road-test/action.yml
@@ -201,17 +201,20 @@ runs:
 
     - name: Detox test (AppleApp ${{ inputs.variant }})
       if: inputs.run-e2e == 'true'
-      run: yarn "$APPLEAPP_E2E_TEST_SCRIPT"
+      run: |
+        rm -rf e2e-artifacts
+        yarn "$APPLEAPP_E2E_TEST_SCRIPT"
       working-directory: apps/AppleApp
       shell: bash
 
-    - name: Upload Detox artifacts on failure
+    - name: Upload Detox recordings on failure
       if: failure() && inputs.run-e2e == 'true'
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
-        name: ${{ inputs.e2e-artifact-name }}-${{ inputs.variant }}-ios
-        path: apps/AppleApp/artifacts
-        if-no-files-found: ignore
+        name: ${{ inputs.e2e-artifact-name }}-${{ inputs.variant }}-ios-recordings
+        path: apps/AppleApp/e2e-artifacts
+        if-no-files-found: warn
+        retention-days: 5
 
     # ==============
 

--- a/.github/actions/prepare-android/action.yml
+++ b/.github/actions/prepare-android/action.yml
@@ -45,7 +45,7 @@ runs:
         android: false
         dotnet: true
         haskell: true
-        large-packages: false
+        large-packages: true
         docker-images: true
         swap-storage: false
 

--- a/.github/actions/prepare-android/action.yml
+++ b/.github/actions/prepare-android/action.yml
@@ -8,9 +8,14 @@ inputs:
     default: 'true'
 
   run-yarn-build:
-    description: 'Whether to run yarn build'
+    description: 'Whether to run yarn build (usually false when ./.github/actions/setup already ran)'
     required: false
-    default: 'true'
+    default: 'false'
+
+  gradle-workflow-job-context:
+    description: 'Segment Gradle cache per app/project (e.g. vanilla, expo54). Falls back to github.job when empty.'
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -23,6 +28,13 @@ runs:
       with:
         distribution: 'zulu'
         java-version: '17'
+
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@6f229686ee4375cc4a86b2514c89bac4930e82c4 # v5
+      with:
+        # Validates all gradle-wrapper.jar files, caches Gradle User Home efficiently,
+        # and captures Build Scan links. Do not combine with actions/cache on ~/.gradle.
+        workflow-job-context: ${{ inputs.gradle-workflow-job-context != '' && inputs.gradle-workflow-job-context || github.job }}
 
     - name: Free Disk Space (Ubuntu)
       if: inputs.free-disk-space == 'true'

--- a/.github/workflows/gradle-plugin-lint.yml
+++ b/.github/workflows/gradle-plugin-lint.yml
@@ -21,16 +21,6 @@ jobs:
           free-disk-space: 'false'
           run-yarn-build: 'false'
 
-      - name: Restore Gradle cache
-        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
       - name: Run Detekt
         working-directory: gradle-plugins/react/brownfield
         run: ./gradlew detekt --no-daemon --stacktrace

--- a/apps/AppleApp/.gitignore
+++ b/apps/AppleApp/.gitignore
@@ -1,2 +1,3 @@
 build
 package
+e2e-artifacts/

--- a/apps/RNApp/.gitignore
+++ b/apps/RNApp/.gitignore
@@ -64,7 +64,7 @@ yarn-error.log
 
 # testing
 /coverage
-/artifacts
+/e2e-artifacts
 
 # Yarn
 .yarn/*

--- a/apps/brownfield-example-shared-tests/detox-artifacts-config.cjs
+++ b/apps/brownfield-example-shared-tests/detox-artifacts-config.cjs
@@ -1,0 +1,37 @@
+'use strict';
+
+/**
+ * Detox artifacts for failed E2E tests (video, screenshots, logs, UI hierarchy).
+ * Written under `<app>/e2e-artifacts/` — upload that folder in CI on failure.
+ *
+ * @param {string} [rootDir='e2e-artifacts']
+ * @returns {import('detox').DetoxArtifactsConfig}
+ */
+function getDetoxArtifactsConfig(rootDir = 'e2e-artifacts') {
+  return {
+    rootDir,
+    plugins: {
+      log: 'failing',
+      screenshot: {
+        shouldTakeAutomaticSnapshots: true,
+        keepOnlyFailedTestsArtifacts: true,
+        takeWhen: {
+          testStart: false,
+          testFailure: true,
+          testDone: true,
+        },
+      },
+      video: {
+        enabled: true,
+        keepOnlyFailedTestsArtifacts: true,
+        simulator: {
+          // h264 is more reliable on GitHub Actions macOS runners than hevc.
+          codec: 'h264',
+        },
+      },
+      uiHierarchy: 'enabled',
+    },
+  };
+}
+
+module.exports = { getDetoxArtifactsConfig };

--- a/apps/brownfield-example-shared-tests/detox-rc-appleapp-ios-sim-debug.cjs
+++ b/apps/brownfield-example-shared-tests/detox-rc-appleapp-ios-sim-debug.cjs
@@ -1,6 +1,7 @@
 'use strict';
 
 const { getIosSimulatorDeviceType } = require('./detox-ios-simulator-device.cjs');
+const { getDetoxArtifactsConfig } = require('./detox-artifacts-config.cjs');
 
 /**
  * Detox iOS Simulator debug config for AppleApp (native Xcode project consumer).
@@ -30,6 +31,7 @@ function createAppleAppIosSimDebugDetoxConfig({
     ` -derivedDataPath build ARCHS=arm64 ONLY_ACTIVE_ARCH=YES CODE_SIGNING_ALLOWED=NO`;
 
   return {
+    artifacts: getDetoxArtifactsConfig(),
     testRunner: {
       $0: 'jest',
       args: {

--- a/apps/brownfield-example-shared-tests/detox-rc-ios-sim-debug.cjs
+++ b/apps/brownfield-example-shared-tests/detox-rc-ios-sim-debug.cjs
@@ -1,6 +1,7 @@
 'use strict';
 
 const { getIosSimulatorDeviceType } = require('./detox-ios-simulator-device.cjs');
+const { getDetoxArtifactsConfig } = require('./detox-artifacts-config.cjs');
 
 /**
  * Shared Detox iOS Simulator debug config for brownfield example apps.
@@ -18,6 +19,7 @@ function createIosSimDebugDetoxConfig({ workspace, scheme, appBinaryName }) {
     ` -derivedDataPath ios/build ARCHS=arm64 ONLY_ACTIVE_ARCH=YES`;
 
   return {
+    artifacts: getDetoxArtifactsConfig(),
     testRunner: {
       $0: 'jest',
       args: {

--- a/apps/brownfield-example-shared-tests/e2e/createDetoxJestConfig.cjs
+++ b/apps/brownfield-example-shared-tests/e2e/createDetoxJestConfig.cjs
@@ -9,7 +9,10 @@ const path = require('node:path');
  */
 function createDetoxJestConfig({ e2eDir, testMatch }) {
   const appRoot = path.join(e2eDir, '..');
-  const sharedTestsRoot = path.join(e2eDir, '../../brownfield-example-shared-tests');
+  const sharedTestsRoot = path.join(
+    e2eDir,
+    '../../brownfield-example-shared-tests'
+  );
 
   return {
     maxWorkers: 1,
@@ -18,7 +21,7 @@ function createDetoxJestConfig({ e2eDir, testMatch }) {
     // Shared E2E files live under brownfield-example-shared-tests; resolve host-app deps (detox) from here.
     modulePaths: [path.join(appRoot, 'node_modules')],
     // beforeEach relaunches the app and waits for the embedded RN surface (up to ~80s on slow CI).
-    testTimeout: 180000,
+    testTimeout: 300000,
     verbose: true,
     reporters: ['detox/runners/jest/reporter'],
     globalSetup: 'detox/runners/jest/globalSetup',

--- a/packages/brownfield-navigation/turbo.json
+++ b/packages/brownfield-navigation/turbo.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "inputs": ["src/**/*"],
+      "outputs": ["lib/**"]
+    }
+  }
+}

--- a/packages/brownfield-navigation/turbo.json
+++ b/packages/brownfield-navigation/turbo.json
@@ -3,7 +3,13 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "inputs": ["src/**/*"],
+      "inputs": [
+        "src/**/*",
+        "bob.config.js",
+        "babel.config.js",
+        "tsconfig*.json",
+        "package.json"
+      ],
       "outputs": ["lib/**"]
     }
   }

--- a/packages/brownfield/turbo.json
+++ b/packages/brownfield/turbo.json
@@ -3,7 +3,13 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "inputs": ["src/**/*"],
+      "inputs": [
+        "src/**/*",
+        "bob.config.js",
+        "babel.config.js",
+        "tsconfig*.json",
+        "package.json"
+      ],
       "outputs": ["dist/**"]
     }
   }

--- a/packages/brownie/turbo.json
+++ b/packages/brownie/turbo.json
@@ -3,7 +3,13 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "inputs": ["src/**/*"],
+      "inputs": [
+        "src/**/*",
+        "bob.config.js",
+        "babel.config.js",
+        "tsconfig*.json",
+        "package.json"
+      ],
       "outputs": ["lib/**"]
     }
   }

--- a/packages/cli/turbo.json
+++ b/packages/cli/turbo.json
@@ -3,7 +3,13 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "inputs": ["src/**/*"],
+      "inputs": [
+        "src/**/*",
+        "bob.config.js",
+        "babel.config.js",
+        "tsconfig*.json",
+        "package.json"
+      ],
       "outputs": ["dist/**"]
     },
     "build:brownfield": {

--- a/packages/react-native-brownfield/turbo.json
+++ b/packages/react-native-brownfield/turbo.json
@@ -3,7 +3,13 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "inputs": ["src/**/*"],
+      "inputs": [
+        "src/**/*",
+        "bob.config.js",
+        "babel.config.js",
+        "tsconfig*.json",
+        "package.json"
+      ],
       "outputs": ["lib/**"]
     }
   }


### PR DESCRIPTION
### Summary

#### CI fixes
- brownfield-navigation Turbo config — turbo.json with lib/** outputs so Turbo cache restores build artifacts (fixes Metro missing NativeBrownfieldNavigation on faulty cache hit).
- Turbo inputs — package turbo.json files include bob/babel/tsconfig config as build inputs.

#### Android CI
- gradle/actions/setup-gradle replaces manual actions/cache on ~/.gradle.
- Per-app Gradle cache via workflow-job-context (flavor: vanilla, expo54, etc.).
- Skip duplicate yarn build in prepare-android when setup already ran.
- ENOSPC prevention - rm RN Android build dirs before AndroidApp assemble

#### iOS E2E
- Detox testTimeout raised from 180s → 300s, which was flaky due to full restart between cases.
- Upload Detox recordings as artifacts.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
CI green.