### PR TITLE
ci: stabilize E2E tests, speed up Android CI, pin actions

### DIFF
--- a/.github/actions/androidapp-road-test/action.yml
+++ b/.github/actions/androidapp-road-test/action.yml
@@ -22,6 +22,12 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: '::group:: Setup & prepare Android'
+      run: |
+        echo "::group::Setup & prepare Android"
+        echo "flavor=${{ inputs.flavor }} rn-project=${{ inputs.rn-project-path }}"
+      shell: bash
+
     - name: Setup
       uses: ./.github/actions/setup
       with:
@@ -33,13 +39,27 @@ runs:
         gradle-workflow-job-context: ${{ inputs.flavor }}
         rn-project-path: ${{ inputs.rn-project-path }}
 
-    # == Brownfield Gradle Plugin ==
+    - name: '::endgroup:: Setup & prepare Android'
+      run: echo "::endgroup::"
+      shell: bash
+
+    - name: '::group:: Brownfield Gradle plugin'
+      run: echo "::group::Brownfield Gradle plugin"
+      shell: bash
+
     - name: Publish Brownfield Gradle Plugin to Maven Local
       run: |
         yarn run brownfield:plugin:publish:local
       shell: bash
 
-    # == RN app ==
+    - name: '::endgroup:: Brownfield Gradle plugin'
+      run: echo "::endgroup::"
+      shell: bash
+
+    - name: '::group:: RN app — prebuild, package & publish AAR'
+      run: echo "::group::RN app — prebuild, package & publish AAR"
+      shell: bash
+
     - name: Prebuild Expo app
       if: ${{ startsWith(inputs.flavor, 'expo') }}
       run: |
@@ -74,14 +94,20 @@ runs:
       run: stat ~/.m2/repository/${{ inputs.rn-project-maven-path }}/0.0.1-SNAPSHOT/brownfieldlib-0.0.1-SNAPSHOT-release.aar
       shell: bash
 
+    - name: '::endgroup:: RN app — prebuild, package & publish AAR'
+      run: echo "::endgroup::"
+      shell: bash
+
+    - name: '::group:: Save ccache & clean RN android outputs'
+      run: echo "::group::Save ccache & clean RN android outputs"
+      shell: bash
+
     - name: Save Android ccache after native AAR build
       uses: actions/cache/save@9255dc7a253b0ccc959486e2bca901246202afeb # v5
       with:
         path: .android_ccache
         key: ${{ runner.os }}-android-ccache-${{ inputs.flavor }}-x86_64-${{ hashFiles('yarn.lock', '**/gradle-wrapper.properties', format('{0}/package.json', inputs.rn-project-path)) }}
 
-    # Compile results are in .android_ccache (saved above + at job end). Drop .cxx CMake trees
-    # and other RN android outputs to avoid ENOSPC before AndroidApp assemble.
     - name: Clean up local RN Android build outputs
       run: |
         ANDROID_DIR="${{ inputs.rn-project-path }}/android"
@@ -94,13 +120,31 @@ runs:
         find "$ANDROID_DIR" -maxdepth 2 -name '.cxx' -type d -prune -exec rm -rf {} +
       shell: bash
 
-    # == AndroidApp ==
+    - name: '::endgroup:: Save ccache & clean RN android outputs'
+      run: echo "::endgroup::"
+      shell: bash
+
+    - name: '::group:: AndroidApp — assemble consumer app'
+      run: echo "::group::AndroidApp — assemble consumer app"
+      shell: bash
 
     - name: Build native Android Brownfield app
       run: yarn run build:example:android-consumer:${{ inputs.flavor }}
+      shell: bash
+
+    - name: '::endgroup:: AndroidApp — assemble consumer app'
+      run: echo "::endgroup::"
+      shell: bash
+
+    - name: '::group:: Summary'
+      run: echo "::group::Summary"
       shell: bash
 
     - name: Log Android ccache stats
       uses: ./.github/actions/ccache-summary
       with:
         name: Android road test (${{ inputs.flavor }})
+
+    - name: '::endgroup:: Summary'
+      run: echo "::endgroup::"
+      shell: bash

--- a/.github/actions/androidapp-road-test/action.yml
+++ b/.github/actions/androidapp-road-test/action.yml
@@ -38,6 +38,7 @@ runs:
       with:
         gradle-workflow-job-context: ${{ inputs.flavor }}
         rn-project-path: ${{ inputs.rn-project-path }}
+        android-ccache: 'true'
 
     - name: '::endgroup:: Setup & prepare Android'
       run: echo "::endgroup::"

--- a/.github/actions/androidapp-road-test/action.yml
+++ b/.github/actions/androidapp-road-test/action.yml
@@ -34,6 +34,7 @@ runs:
         restore-turbo-cache: ${{ inputs.restore-turbo-cache }}
 
     - name: Prepare Android environment
+      id: prepare-android
       uses: ./.github/actions/prepare-android
       with:
         gradle-workflow-job-context: ${{ inputs.flavor }}
@@ -99,15 +100,9 @@ runs:
       run: echo "::endgroup::"
       shell: bash
 
-    - name: '::group:: Save ccache & clean RN android outputs'
-      run: echo "::group::Save ccache & clean RN android outputs"
+    - name: '::group:: Clean RN android outputs'
+      run: echo "::group::Clean RN android outputs"
       shell: bash
-
-    - name: Save Android ccache after native AAR build
-      uses: actions/cache/save@9255dc7a253b0ccc959486e2bca901246202afeb # v5
-      with:
-        path: .android_ccache
-        key: ${{ runner.os }}-android-ccache-${{ inputs.flavor }}-x86_64-${{ hashFiles('yarn.lock', '**/gradle-wrapper.properties', format('{0}/package.json', inputs.rn-project-path)) }}
 
     - name: Clean up local RN Android build outputs
       run: |
@@ -121,7 +116,7 @@ runs:
         find "$ANDROID_DIR" -maxdepth 2 -name '.cxx' -type d -prune -exec rm -rf {} +
       shell: bash
 
-    - name: '::endgroup:: Save ccache & clean RN android outputs'
+    - name: '::endgroup:: Clean RN android outputs'
       run: echo "::endgroup::"
       shell: bash
 
@@ -137,15 +132,22 @@ runs:
       run: echo "::endgroup::"
       shell: bash
 
-    - name: '::group:: Summary'
-      run: echo "::group::Summary"
+    - name: '::group:: Save ccache & summary'
+      run: echo "::group::Save ccache & summary"
       shell: bash
+
+    - name: Save Android ccache
+      if: steps.prepare-android.outputs.android-ccache-cache-hit != 'true'
+      uses: actions/cache/save@9255dc7a253b0ccc959486e2bca901246202afeb # v5
+      with:
+        path: .android_ccache
+        key: ${{ steps.prepare-android.outputs.android-ccache-cache-primary-key }}
 
     - name: Log Android ccache stats
       uses: ./.github/actions/ccache-summary
       with:
         name: Android road test (${{ inputs.flavor }})
 
-    - name: '::endgroup:: Summary'
+    - name: '::endgroup:: Save ccache & summary'
       run: echo "::endgroup::"
       shell: bash

--- a/.github/actions/androidapp-road-test/action.yml
+++ b/.github/actions/androidapp-road-test/action.yml
@@ -31,6 +31,7 @@ runs:
       uses: ./.github/actions/prepare-android
       with:
         gradle-workflow-job-context: ${{ inputs.flavor }}
+        rn-project-path: ${{ inputs.rn-project-path }}
 
     # == Brownfield Gradle Plugin ==
     - name: Publish Brownfield Gradle Plugin to Maven Local
@@ -73,16 +74,24 @@ runs:
       run: stat ~/.m2/repository/${{ inputs.rn-project-maven-path }}/0.0.1-SNAPSHOT/brownfieldlib-0.0.1-SNAPSHOT-release.aar
       shell: bash
 
-    # clean up build artifacts to ensure no ENOSPC
-    - name: Clean up local build artifacts
+    - name: Save Android ccache after native AAR build
+      uses: actions/cache/save@9255dc7a253b0ccc959486e2bca901246202afeb # v5
+      with:
+        path: .android_ccache
+        key: ${{ runner.os }}-android-ccache-${{ inputs.flavor }}-x86_64-${{ hashFiles('yarn.lock', '**/gradle-wrapper.properties', format('{0}/package.json', inputs.rn-project-path)) }}
+
+    # Compile results are in .android_ccache (saved above + at job end). Drop .cxx CMake trees
+    # and other RN android outputs to avoid ENOSPC before AndroidApp assemble.
+    - name: Clean up local RN Android build outputs
       run: |
-        rm -rf ${{ inputs.rn-project-path }}/android/build
-        rm -rf ${{ inputs.rn-project-path }}/android/.cxx
-        rm -rf ${{ inputs.rn-project-path }}/android/.gradle
-        rm -rf ${{ inputs.rn-project-path }}/android/app/build
-        rm -rf ${{ inputs.rn-project-path }}/android/app/.cxx
-        rm -rf ${{ inputs.rn-project-path }}/android/app/.gradle
-        rm -rf ${{ inputs.rn-project-path }}/android/app/build
+        ANDROID_DIR="${{ inputs.rn-project-path }}/android"
+        rm -rf "$ANDROID_DIR/build"
+        rm -rf "$ANDROID_DIR/.cxx"
+        rm -rf "$ANDROID_DIR/.gradle"
+        rm -rf "$ANDROID_DIR/app/build"
+        rm -rf "$ANDROID_DIR/app/.cxx"
+        rm -rf "$ANDROID_DIR/app/.gradle"
+        find "$ANDROID_DIR" -maxdepth 2 -name '.cxx' -type d -prune -exec rm -rf {} +
       shell: bash
 
     # == AndroidApp ==
@@ -90,3 +99,8 @@ runs:
     - name: Build native Android Brownfield app
       run: yarn run build:example:android-consumer:${{ inputs.flavor }}
       shell: bash
+
+    - name: Log Android ccache stats
+      uses: ./.github/actions/ccache-summary
+      with:
+        name: Android road test (${{ inputs.flavor }})

--- a/.github/actions/appleapp-road-test/action.yml
+++ b/.github/actions/appleapp-road-test/action.yml
@@ -118,6 +118,13 @@ runs:
         pod install
       shell: bash
 
+    - name: Apply Brownfield Debug pod settings (E2E)
+      if: inputs.variant == 'vanilla' && inputs.run-e2e == 'true'
+      run: |
+        source scripts/ci-local-ios-e2e-common.sh
+        ci_local_e2e_apply_brownfield_debug_pod_settings "${{ github.workspace }}/${{ inputs.rn-project-path }}/ios"
+      shell: bash
+
     - name: Install pods (RN ${{ inputs.variant }} app)
       if: inputs.variant == 'vanilla' && inputs.run-e2e != 'true'
       run: |

--- a/.github/actions/appleapp-road-test/action.yml
+++ b/.github/actions/appleapp-road-test/action.yml
@@ -250,7 +250,7 @@ runs:
 
     - name: Upload Detox recordings on failure
       if: failure() && inputs.run-e2e == 'true'
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ inputs.e2e-artifact-name }}-${{ inputs.variant }}-ios-recordings
         path: apps/AppleApp/e2e-artifacts

--- a/.github/actions/appleapp-road-test/action.yml
+++ b/.github/actions/appleapp-road-test/action.yml
@@ -28,6 +28,10 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: '::group:: Setup & prepare iOS'
+      run: echo "::group::Setup & prepare iOS"
+      shell: bash
+
     - name: Setup
       uses: ./.github/actions/setup
       with:
@@ -35,6 +39,14 @@ runs:
 
     - name: Prepare iOS environment
       uses: ./.github/actions/prepare-ios
+
+    - name: '::endgroup:: Setup & prepare iOS'
+      run: echo "::endgroup::"
+      shell: bash
+
+    - name: '::group:: ccache & iOS build caches'
+      run: echo "::group::ccache & iOS build caches"
+      shell: bash
 
     - name: Configure ccache environment
       run: |
@@ -60,7 +72,7 @@ runs:
       shell: bash
 
     - name: Restore AppleApp ccache
-      uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: |
           .ios_ccache
@@ -68,10 +80,18 @@ runs:
         restore-keys: |
           ${{ runner.os }}-rnapp-appleapp-${{ inputs.variant }}-ios-ccache-
 
-    # == RN app ==
+    - name: '::endgroup:: ccache & iOS build caches'
+      run: echo "::endgroup::"
+      shell: bash
+
+    - name: '::group:: RN app — pods & package iOS XCFramework'
+      run: |
+        echo "::group::RN app — pods & package iOS XCFramework"
+        echo "variant=${{ inputs.variant }} rn-project=${{ inputs.rn-project-path }}"
+      shell: bash
 
     - name: Restore Pods cache (RN ${{ inputs.variant }} app)
-      uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: |
           ${{ inputs.rn-project-path }}/ios/Pods
@@ -106,7 +126,7 @@ runs:
       shell: bash
 
     - name: Restore DerivedData cache (RN ${{ inputs.variant }} app)
-      uses: actions/cache@v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ${{ inputs.rn-project-path }}/ios/build
         key: ${{ runner.os }}-ios-rnapp-${{ inputs.variant }}-derived-data-${{ hashFiles(format('{0}/ios/Podfile.lock', inputs.rn-project-path), format('{0}/ios/*.xcodeproj/project.pbxproj', inputs.rn-project-path)) }}
@@ -119,12 +139,29 @@ runs:
         yarn run brownfield:package:ios
       shell: bash
 
-    # == AppleApp ==
+    - name: '::endgroup:: RN app — pods & package iOS XCFramework'
+      run: echo "::endgroup::"
+      shell: bash
+
+    - name: '::group:: AppleApp — Release road test build'
+      if: inputs.run-e2e != 'true'
+      run: echo "::group::AppleApp — Release road test build"
+      shell: bash
 
     - name: Build Brownfield iOS native app (${{ inputs.variant }})
       if: inputs.run-e2e != 'true'
       run: |
         yarn run build:example:ios-consumer:${{ inputs.variant }}
+      shell: bash
+
+    - name: '::endgroup:: AppleApp — Release road test build'
+      if: inputs.run-e2e != 'true'
+      run: echo "::endgroup::"
+      shell: bash
+
+    - name: '::group:: AppleApp — Detox E2E'
+      if: inputs.run-e2e == 'true'
+      run: echo "::group::AppleApp — Detox E2E"
       shell: bash
 
     - name: Resolve AppleApp E2E settings
@@ -154,7 +191,7 @@ runs:
 
     - name: Restore Detox build cache (AppleApp)
       if: inputs.run-e2e == 'true'
-      uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: apps/AppleApp/build
         key: ${{ runner.os }}-e2e-appleapp-${{ inputs.variant }}-build-${{ hashFiles(format('{0}/ios/Podfile.lock', inputs.rn-project-path), 'apps/AppleApp/Brownfield Apple App.xcodeproj/project.pbxproj', 'apps/brownfield-example-shared-tests/e2e/**') }}
@@ -176,6 +213,7 @@ runs:
     - name: Verify embedded JS bundle in BrownfieldLib (E2E)
       if: inputs.run-e2e == 'true'
       run: |
+        echo "::group::Verify embedded JS bundle"
         set -euo pipefail
         PRODUCTS_DIR="apps/AppleApp/build/Build/Products/${APPLEAPP_E2E_CONFIGURATION}-iphonesimulator"
         APP_PATH="$(find "$PRODUCTS_DIR" -maxdepth 1 -name '*.app' -print -quit)"
@@ -197,13 +235,16 @@ runs:
         fi
         echo "App executable OK: $EXECUTABLE_PATH ($(wc -c < "$EXECUTABLE_PATH") bytes)"
         echo "Embedded bundle OK: $BUNDLE_PATH ($(wc -c < "$BUNDLE_PATH") bytes)"
+        echo "::endgroup::"
       shell: bash
 
     - name: Detox test (AppleApp ${{ inputs.variant }})
       if: inputs.run-e2e == 'true'
       run: |
+        echo "::group::Detox test"
         rm -rf e2e-artifacts
         yarn "$APPLEAPP_E2E_TEST_SCRIPT"
+        echo "::endgroup::"
       working-directory: apps/AppleApp
       shell: bash
 
@@ -216,9 +257,20 @@ runs:
         if-no-files-found: warn
         retention-days: 5
 
-    # ==============
+    - name: '::endgroup:: AppleApp — Detox E2E'
+      if: always() && inputs.run-e2e == 'true'
+      run: echo "::endgroup::"
+      shell: bash
+
+    - name: '::group:: Summary'
+      run: echo "::group::Summary"
+      shell: bash
 
     - name: Log ccache stats
       uses: ./.github/actions/ccache-summary
       with:
         name: RN ${{ inputs.variant }} app & AppleApp
+
+    - name: '::endgroup:: Summary'
+      run: echo "::endgroup::"
+      shell: bash

--- a/.github/actions/appleapp-road-test/action.yml
+++ b/.github/actions/appleapp-road-test/action.yml
@@ -64,6 +64,7 @@ runs:
       if: inputs.run-e2e == 'true'
       run: |
         brew tap wix/brew
+        brew trust --formula wix/brew/applesimutils
         brew install applesimutils
       shell: bash
 

--- a/.github/actions/ccache-summary/action.yml
+++ b/.github/actions/ccache-summary/action.yml
@@ -10,5 +10,10 @@ runs:
   using: composite
   steps:
     - name: Log ccache stats
-      run: ccache -s > $GITHUB_STEP_SUMMARY
+      run: |
+        {
+          echo "### ${{ inputs.name }}"
+          echo
+          ccache -s
+        } >> "$GITHUB_STEP_SUMMARY"
       shell: bash

--- a/.github/actions/prepare-android/action.yml
+++ b/.github/actions/prepare-android/action.yml
@@ -12,8 +12,13 @@ inputs:
     required: false
     default: 'false'
 
-  disable-cache:
-    description: 'Disable Gradle and Android ccache restore (use for release/publish workflows)'
+  gradle-cache:
+    description: 'Enable Gradle User Home cache restore/save via setup-gradle'
+    required: false
+    default: 'true'
+
+  android-ccache:
+    description: 'Install, restore, and allow saving Android ccache (native JNI builds only)'
     required: false
     default: 'false'
 
@@ -49,7 +54,7 @@ runs:
         # Validates all gradle-wrapper.jar files, caches Gradle User Home efficiently,
         # and captures Build Scan links. Do not combine with actions/cache on ~/.gradle.
         workflow-job-context: ${{ inputs.gradle-workflow-job-context != '' && inputs.gradle-workflow-job-context || github.job }}
-        cache-disabled: ${{ inputs.disable-cache == 'true' }}
+        cache-disabled: ${{ inputs.gradle-cache != 'true' }}
 
     # ubuntu-latest is x86_64; match the emulator ABI so CI only compiles one JNI arch.
     - name: Limit native builds to runner emulator ABI
@@ -88,14 +93,17 @@ runs:
       shell: bash
 
     - name: '::group:: Android ccache'
+      if: inputs.android-ccache == 'true'
       run: echo "::group::Android ccache"
       shell: bash
 
     - name: Install ccache
+      if: inputs.android-ccache == 'true'
       run: sudo apt-get update && sudo apt-get install -y ccache
       shell: bash
 
     - name: Configure Android ccache
+      if: inputs.android-ccache == 'true'
       run: |
         mkdir -p "${GITHUB_WORKSPACE}/.android_ccache"
         echo "compiler_check = content" > "${GITHUB_WORKSPACE}/.android_ccache.conf"
@@ -106,7 +114,7 @@ runs:
       shell: bash
 
     - name: Restore Android ccache
-      if: inputs.disable-cache != 'true'
+      if: inputs.android-ccache == 'true'
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: .android_ccache
@@ -115,6 +123,7 @@ runs:
           ${{ runner.os }}-android-ccache-${{ inputs.gradle-workflow-job-context != '' && inputs.gradle-workflow-job-context || github.job }}-
 
     - name: '::endgroup:: Android ccache'
+      if: inputs.android-ccache == 'true'
       run: echo "::endgroup::"
       shell: bash
 

--- a/.github/actions/prepare-android/action.yml
+++ b/.github/actions/prepare-android/action.yml
@@ -17,6 +17,11 @@ inputs:
     required: false
     default: ''
 
+  rn-project-path:
+    description: 'Optional RN app path for native ccache key segmentation (e.g. apps/ExpoApp55)'
+    required: false
+    default: ''
+
 runs:
   using: composite
   steps:
@@ -59,6 +64,28 @@ runs:
         "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" --install "ndk;27.0.12077973"
         test -d "$ANDROID_HOME/ndk/27.0.12077973"
       shell: bash
+
+    - name: Install ccache
+      run: sudo apt-get update && sudo apt-get install -y ccache
+      shell: bash
+
+    - name: Configure Android ccache
+      run: |
+        mkdir -p "${GITHUB_WORKSPACE}/.android_ccache"
+        echo "compiler_check = content" > "${GITHUB_WORKSPACE}/.android_ccache.conf"
+        echo "CCACHE_CONFIGPATH=${GITHUB_WORKSPACE}/.android_ccache.conf" >> "$GITHUB_ENV"
+        echo "CCACHE_DIR=${GITHUB_WORKSPACE}/.android_ccache" >> "$GITHUB_ENV"
+        echo "CCACHE_BASEDIR=${GITHUB_WORKSPACE}" >> "$GITHUB_ENV"
+        echo "CCACHE_COMPRESS=1" >> "$GITHUB_ENV"
+      shell: bash
+
+    - name: Restore Android ccache
+      uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5
+      with:
+        path: .android_ccache
+        key: ${{ runner.os }}-android-ccache-${{ inputs.gradle-workflow-job-context != '' && inputs.gradle-workflow-job-context || github.job }}-x86_64-${{ hashFiles('yarn.lock', '**/gradle-wrapper.properties', inputs.rn-project-path != '' && format('{0}/package.json', inputs.rn-project-path) || 'package.json') }}
+        restore-keys: |
+          ${{ runner.os }}-android-ccache-${{ inputs.gradle-workflow-job-context != '' && inputs.gradle-workflow-job-context || github.job }}-
 
     - name: Build packages
       if: inputs.run-yarn-build == 'true'

--- a/.github/actions/prepare-android/action.yml
+++ b/.github/actions/prepare-android/action.yml
@@ -80,7 +80,7 @@ runs:
       shell: bash
 
     - name: Restore Android ccache
-      uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: .android_ccache
         key: ${{ runner.os }}-android-ccache-${{ inputs.gradle-workflow-job-context != '' && inputs.gradle-workflow-job-context || github.job }}-x86_64-${{ hashFiles('yarn.lock', '**/gradle-wrapper.properties', inputs.rn-project-path != '' && format('{0}/package.json', inputs.rn-project-path) || 'package.json') }}

--- a/.github/actions/prepare-android/action.yml
+++ b/.github/actions/prepare-android/action.yml
@@ -25,6 +25,10 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: '::group:: Gradle & Java'
+      run: echo "::group::Gradle & Java"
+      shell: bash
+
     - name: Validate Gradle Wrapper
       uses: gradle/actions/wrapper-validation@6f229686ee4375cc4a86b2514c89bac4930e82c4 # v5
 
@@ -46,6 +50,14 @@ runs:
       run: echo "ORG_GRADLE_PROJECT_reactNativeArchitectures=x86_64" >> "$GITHUB_ENV"
       shell: bash
 
+    - name: '::endgroup:: Gradle & Java'
+      run: echo "::endgroup::"
+      shell: bash
+
+    - name: '::group:: Disk space & Android NDK'
+      run: echo "::group::Disk space & Android NDK"
+      shell: bash
+
     - name: Free Disk Space (Ubuntu)
       if: inputs.free-disk-space == 'true'
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
@@ -63,6 +75,14 @@ runs:
       run: |
         "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" --install "ndk;27.0.12077973"
         test -d "$ANDROID_HOME/ndk/27.0.12077973"
+      shell: bash
+
+    - name: '::endgroup:: Disk space & Android NDK'
+      run: echo "::endgroup::"
+      shell: bash
+
+    - name: '::group:: Android ccache'
+      run: echo "::group::Android ccache"
       shell: bash
 
     - name: Install ccache
@@ -87,7 +107,21 @@ runs:
         restore-keys: |
           ${{ runner.os }}-android-ccache-${{ inputs.gradle-workflow-job-context != '' && inputs.gradle-workflow-job-context || github.job }}-
 
+    - name: '::endgroup:: Android ccache'
+      run: echo "::endgroup::"
+      shell: bash
+
+    - name: '::group:: Build packages'
+      if: inputs.run-yarn-build == 'true'
+      run: echo "::group::Build packages"
+      shell: bash
+
     - name: Build packages
       if: inputs.run-yarn-build == 'true'
       run: yarn build
+      shell: bash
+
+    - name: '::endgroup:: Build packages'
+      if: inputs.run-yarn-build == 'true'
+      run: echo "::endgroup::"
       shell: bash

--- a/.github/actions/prepare-android/action.yml
+++ b/.github/actions/prepare-android/action.yml
@@ -12,6 +12,11 @@ inputs:
     required: false
     default: 'false'
 
+  disable-cache:
+    description: 'Disable Gradle and Android ccache restore (use for release/publish workflows)'
+    required: false
+    default: 'false'
+
   gradle-workflow-job-context:
     description: 'Segment Gradle cache per app/project (e.g. vanilla, expo54). Falls back to github.job when empty.'
     required: false
@@ -44,6 +49,7 @@ runs:
         # Validates all gradle-wrapper.jar files, caches Gradle User Home efficiently,
         # and captures Build Scan links. Do not combine with actions/cache on ~/.gradle.
         workflow-job-context: ${{ inputs.gradle-workflow-job-context != '' && inputs.gradle-workflow-job-context || github.job }}
+        cache-disabled: ${{ inputs.disable-cache == 'true' }}
 
     # ubuntu-latest is x86_64; match the emulator ABI so CI only compiles one JNI arch.
     - name: Limit native builds to runner emulator ABI
@@ -100,6 +106,7 @@ runs:
       shell: bash
 
     - name: Restore Android ccache
+      if: inputs.disable-cache != 'true'
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: .android_ccache

--- a/.github/actions/prepare-android/action.yml
+++ b/.github/actions/prepare-android/action.yml
@@ -32,6 +32,14 @@ inputs:
     required: false
     default: ''
 
+outputs:
+  android-ccache-cache-hit:
+    description: 'Whether Android ccache restore matched the primary cache key exactly'
+    value: ${{ steps.android-ccache-restore.outputs.cache-hit }}
+  android-ccache-cache-primary-key:
+    description: 'Primary cache key used for Android ccache restore/save'
+    value: ${{ steps.android-ccache-restore.outputs.cache-primary-key }}
+
 runs:
   using: composite
   steps:
@@ -114,8 +122,9 @@ runs:
       shell: bash
 
     - name: Restore Android ccache
+      id: android-ccache-restore
       if: inputs.android-ccache == 'true'
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb # v5
       with:
         path: .android_ccache
         key: ${{ runner.os }}-android-ccache-${{ inputs.gradle-workflow-job-context != '' && inputs.gradle-workflow-job-context || github.job }}-x86_64-${{ hashFiles('yarn.lock', '**/gradle-wrapper.properties', inputs.rn-project-path != '' && format('{0}/package.json', inputs.rn-project-path) || 'package.json') }}

--- a/.github/actions/prepare-android/action.yml
+++ b/.github/actions/prepare-android/action.yml
@@ -36,6 +36,11 @@ runs:
         # and captures Build Scan links. Do not combine with actions/cache on ~/.gradle.
         workflow-job-context: ${{ inputs.gradle-workflow-job-context != '' && inputs.gradle-workflow-job-context || github.job }}
 
+    # ubuntu-latest is x86_64; match the emulator ABI so CI only compiles one JNI arch.
+    - name: Limit native builds to runner emulator ABI
+      run: echo "ORG_GRADLE_PROJECT_reactNativeArchitectures=x86_64" >> "$GITHUB_ENV"
+      shell: bash
+
     - name: Free Disk Space (Ubuntu)
       if: inputs.free-disk-space == 'true'
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1

--- a/.github/actions/prepare-ios/action.yml
+++ b/.github/actions/prepare-ios/action.yml
@@ -10,6 +10,10 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: '::group:: Xcode & Ruby'
+      run: echo "::group::Xcode & Ruby"
+      shell: bash
+
     - name: Use appropriate Xcode version
       uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
       with:
@@ -21,7 +25,21 @@ runs:
         ruby-version: '3.2'
         bundler-cache: true
 
+    - name: '::endgroup:: Xcode & Ruby'
+      run: echo "::endgroup::"
+      shell: bash
+
+    - name: '::group:: Build packages'
+      if: inputs.run-yarn-build == 'true'
+      run: echo "::group::Build packages"
+      shell: bash
+
     - name: Build packages
       if: inputs.run-yarn-build == 'true'
       run: yarn build
+      shell: bash
+
+    - name: '::endgroup:: Build packages'
+      if: inputs.run-yarn-build == 'true'
+      run: echo "::endgroup::"
       shell: bash

--- a/.github/actions/prepare-ios/action.yml
+++ b/.github/actions/prepare-ios/action.yml
@@ -15,7 +15,7 @@ runs:
       shell: bash
 
     - name: Use appropriate Xcode version
-      uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
+      uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
       with:
         xcode-version: '26.3'
 

--- a/.github/actions/prepare-ios/action.yml
+++ b/.github/actions/prepare-ios/action.yml
@@ -20,7 +20,7 @@ runs:
         xcode-version: '26.3'
 
     - name: Setup Ruby
-      uses: ruby/setup-ruby@5dd816ae0186f20dfa905997a64104db9a8221c7 # v1.280.0
+      uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
       with:
         ruby-version: '3.2'
         bundler-cache: true

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -14,11 +14,19 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Setup Node.js
+    - name: Setup Node.js (with cache)
+      if: inputs.disable-cache != 'true'
       uses: actions/setup-node@65d868f8d4d85d7d4abb7de0875cde3fcc8798f5 # v6
       with:
         node-version: 'lts/*'
-        cache: ${{ inputs.disable-cache != 'true' && 'yarn' || '' }}
+        cache: 'yarn'
+
+    - name: Setup Node.js (no cache)
+      if: inputs.disable-cache == 'true'
+      uses: actions/setup-node@65d868f8d4d85d7d4abb7de0875cde3fcc8798f5 # v6
+      with:
+        node-version: 'lts/*'
+        package-manager-cache: false
 
     - name: Restore Turbo cache
       if: inputs.disable-cache != 'true' && inputs.restore-turbo-cache == 'true'

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -18,7 +18,7 @@ runs:
 
     - name: Restore Turbo cache
       if: inputs.restore-turbo-cache == 'true'
-      uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: |
           .turbo

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -2,6 +2,10 @@ name: Setup
 description: Setup Node.js and install dependencies
 
 inputs:
+  disable-cache:
+    description: 'Disable Node.js yarn cache and Turbo cache restore (use for release/publish workflows)'
+    required: false
+    default: 'false'
   restore-turbo-cache:
     description: 'Whether to restore the Turbo cache'
     required: false
@@ -14,10 +18,10 @@ runs:
       uses: actions/setup-node@65d868f8d4d85d7d4abb7de0875cde3fcc8798f5 # v6
       with:
         node-version: 'lts/*'
-        cache: 'yarn'
+        cache: ${{ inputs.disable-cache != 'true' && 'yarn' || '' }}
 
     - name: Restore Turbo cache
-      if: inputs.restore-turbo-cache == 'true'
+      if: inputs.disable-cache != 'true' && inputs.restore-turbo-cache == 'true'
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
 
       - name: Filter paths
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |
@@ -237,4 +237,3 @@ jobs:
           rn-project-path: apps/ExpoApp${{ matrix.version }}
           run-e2e: ${{ matrix.run-e2e }}
           e2e-artifact-name: detox-appleapp-expo${{ matrix.version }}
-

--- a/.github/workflows/expo-beta-road-test.yml
+++ b/.github/workflows/expo-beta-road-test.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  actions: read
+  actions: write
   contents: read
   issues: write
 

--- a/.github/workflows/expo-beta-road-test.yml
+++ b/.github/workflows/expo-beta-road-test.yml
@@ -148,7 +148,7 @@ jobs:
           printf '%s\n' '${{ needs.prepare.outputs.latest_version }}' > expo-beta-test-result/version.txt
 
       - name: Upload Expo beta success marker
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: expo-beta-tested-${{ needs.prepare.outputs.latest_version }}
           path: expo-beta-test-result/version.txt

--- a/.github/workflows/gradle-plugin-lint.yml
+++ b/.github/workflows/gradle-plugin-lint.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           free-disk-space: 'false'
           run-yarn-build: 'false'
+          android-ccache: 'false'
 
       - name: Run Detekt
         working-directory: gradle-plugins/react/brownfield

--- a/.github/workflows/release-brownfield-gradle-plugin.yml
+++ b/.github/workflows/release-brownfield-gradle-plugin.yml
@@ -148,7 +148,7 @@ jobs:
           path: gradle-plugins/react/brownfield/build/staging-deploy
 
       - name: Run JReleaser
-        uses: jreleaser/release-action@v2
+        uses: jreleaser/release-action@90ac653bb9c79d11179e65d81499f3f34527dcd5 # v2.5.0
         with:
           arguments: full-release
         env:

--- a/.github/workflows/release-brownfield-gradle-plugin.yml
+++ b/.github/workflows/release-brownfield-gradle-plugin.yml
@@ -40,13 +40,14 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
         with:
-          restore-turbo-cache: 'false'
+          disable-cache: 'true'
 
       - name: Prepare Android environment
         uses: ./.github/actions/prepare-android
         with:
           free-disk-space: 'false'
           run-yarn-build: 'false'
+          disable-cache: 'true'
 
       - name: Derive release metadata
         id: metadata

--- a/.github/workflows/release-brownfield-gradle-plugin.yml
+++ b/.github/workflows/release-brownfield-gradle-plugin.yml
@@ -47,7 +47,8 @@ jobs:
         with:
           free-disk-space: 'false'
           run-yarn-build: 'false'
-          disable-cache: 'true'
+          gradle-cache: 'false'
+          android-ccache: 'false'
 
       - name: Derive release metadata
         id: metadata

--- a/.github/workflows/release-brownfield-gradle-plugin.yml
+++ b/.github/workflows/release-brownfield-gradle-plugin.yml
@@ -105,13 +105,13 @@ jobs:
             --stacktrace
 
       - name: Upload release notes artifact
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: brownfield-gradle-plugin-release-notes
           path: out/jreleaser/brownfield-gradle-plugin-release-notes.md
 
       - name: Upload staged Maven repository artifact
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: brownfield-gradle-plugin-staging-repo
           path: gradle-plugins/react/brownfield/build/staging-deploy
@@ -165,7 +165,7 @@ jobs:
 
       - name: Upload JReleaser output
         if: always()
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: brownfield-gradle-plugin-jreleaser-output
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
         with:
-          restore-turbo-cache: 'false' # in release workflow, build from scratch
+          disable-cache: 'true'
 
 
       - name: Build

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ local.properties
 *.iml
 *.hprof
 **/.cxx/
+.android_ccache/
+.android_ccache.conf
+.ios_ccache/
 *.keystore
 !debug.keystore
 .kotlin/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ After contributing your changes, please make sure to add a [changeset](https://g
 
 ### Pre-commit guard for brownfield-navigation
 
- This is a monorepo and the files inside `@callstack/brownfield-navigation` are auto-generated whenever `brownfield:package:*` is run. This is a desired behavior for the end user as these files will be inside the `node_modules`. However, since in this repo this package is symlinked, we see the changes in our git tree.
+This is a monorepo and the files inside `@callstack/brownfield-navigation` are auto-generated whenever `brownfield:package:*` is run. This is a desired behavior for the end user as these files will be inside the `node_modules`. However, since in this repo this package is symlinked, we see the changes in our git tree.
 
 These should not be committed by accident. A `pre-commit` guard blocks commits when those generated files are staged.
 
@@ -75,11 +75,11 @@ There are 2 brownfield host apps.
 
 For iOS, these scripts validate the legacy direct-XCFramework integration path. Each script uses the previously packaged artifacts from the respective directory (`apps/RNApp`, `apps/ExpoApp54`, or `apps/ExpoApp55`), invokes `prepareXCFrameworks.js` to copy XCFrameworks into `apps/AppleApp/package`, then runs `xcodebuild` against the matching scheme. The Xcode project reads fixed paths under `package/` (for example `package/BrownfieldLib.xcframework`).
 
-| Yarn script | RN app | Xcode target | Scheme | Configuration |
-| --- | --- | --- | --- | --- |
-| `build:example:ios-consumer:vanilla` | `RNApp` | `Brownfield Apple App (RNApp)` | Brownfield Apple App Vanilla | `Release Vanilla` |
-| `build:example:ios-consumer:expo54` | `ExpoApp54` | `Brownfield Apple App (ExpoApp54)` | Brownfield Apple App Expo 54 | `Release` |
-| `build:example:ios-consumer:expo55` | `ExpoApp55` | `Brownfield Apple App (ExpoApp55)` | Brownfield Apple App Expo 55 | `Release` |
+| Yarn script                          | RN app      | Xcode target                       | Scheme                       | Configuration     |
+| ------------------------------------ | ----------- | ---------------------------------- | ---------------------------- | ----------------- |
+| `build:example:ios-consumer:vanilla` | `RNApp`     | `Brownfield Apple App (RNApp)`     | Brownfield Apple App Vanilla | `Release Vanilla` |
+| `build:example:ios-consumer:expo54`  | `ExpoApp54` | `Brownfield Apple App (ExpoApp54)` | Brownfield Apple App Expo 54 | `Release`         |
+| `build:example:ios-consumer:expo55`  | `ExpoApp55` | `Brownfield Apple App (ExpoApp55)` | Brownfield Apple App Expo 55 | `Release`         |
 
 > [!IMPORTANT]
 > You can build and run `AppleApp` from the Xcode GUI by selecting the scheme for the variant you want. Before running, after switching schemes or re-packaging an RN app, run the matching `build:example:ios-consumer:...` script so fresh artifacts are present in `apps/AppleApp/package`. Otherwise Xcode will still link against the previous XCFrameworks.
@@ -111,18 +111,82 @@ The React Native example apps share Jest utilities and test suites from `apps/br
 
 From the repository root:
 
-| Command | Description |
-| --- | --- |
+| Command          | Description                                                             |
+| ---------------- | ----------------------------------------------------------------------- |
 | `yarn test:apps` | Runs `test` in all workspaces under `apps/` that define it (via Turbo). |
 
 Per example app (run from the repo root):
 
-| Command | App |
-| --- | --- |
-| `yarn workspace @callstack/brownfield-example-rn-app test` | Plain React Native (`apps/RNApp`) |
-| `yarn workspace @callstack/brownfield-example-expo-app-54 test` | Expo SDK 54 (`apps/ExpoApp54`) |
-| `yarn workspace @callstack/brownfield-example-expo-app-55 test` | Expo SDK 55 (`apps/ExpoApp55`) |
+| Command                                                         | App                               |
+| --------------------------------------------------------------- | --------------------------------- |
+| `yarn workspace @callstack/brownfield-example-rn-app test`      | Plain React Native (`apps/RNApp`) |
+| `yarn workspace @callstack/brownfield-example-expo-app-54 test` | Expo SDK 54 (`apps/ExpoApp54`)    |
+| `yarn workspace @callstack/brownfield-example-expo-app-55 test` | Expo SDK 55 (`apps/ExpoApp55`)    |
 
 Package-level scripts (`yarn test` inside `apps/RNApp`, `apps/ExpoApp54`, or `apps/ExpoApp55`) invoke Jest with each app’s `jest.config.js`.
 
 The native-only sample apps (`apps/AppleApp`, `apps/AndroidApp`) use their platform test runners (Xcode / Gradle), not Jest.
+
+## E2E tests (Detox)
+
+End-to-end tests use [Detox](https://wix.github.io/Detox/) on the iOS Simulator. Shared specs and helpers live in `apps/brownfield-example-shared-tests/e2e/`; each app wires them through its own `.detoxrc.cjs` and `e2e/jest.config.cjs`.
+
+E2E runs without Metro: the Debug simulator build embeds `main.jsbundle` (`FORCE_BUNDLING=1`) so the app loads JS from the binary, matching CI.
+
+### Two integration paths
+
+| Path                                            | What it exercises                                                | Typical flow                                                                                    |
+| ----------------------------------------------- | ---------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| RN host app (`RNApp`, `ExpoApp54`, `ExpoApp55`) | Brownfield RN app running as the simulator target                | `expo prebuild` / pods → Detox build → Detox test                                               |
+| native host app (`AppleApp`)                    | Native host app consuming a packaged `BrownfieldLib` XCFramework | `brownfield:package:ios` → copy XCFrameworks into `AppleApp/package` → Detox build → Detox test |
+
+Per-app Detox scripts (run from the app directory):
+
+| App                       | Build                       | Test                       | Shared spec                        |
+| ------------------------- | --------------------------- | -------------------------- | ---------------------------------- |
+| `RNApp`                   | `yarn e2e:build:ios`        | `yarn e2e:test:ios`        | `rnAppBrownfield.e2e.js`           |
+| `ExpoApp54` / `ExpoApp55` | `yarn e2e:build:ios`        | `yarn e2e:test:ios`        | `expoPostMessageBrownfield.e2e.js` |
+| `AppleApp` (vanilla)      | `yarn e2e:build:ios`        | `yarn e2e:test:ios`        | `appleAppBrownfield.e2e.js`        |
+| `AppleApp` (Expo 55)      | `yarn e2e:build:ios:expo55` | `yarn e2e:test:ios:expo55` | `appleAppExpoBrownfield.e2e.js`    |
+
+### CI
+
+iOS Detox E2E runs in [`.github/workflows/ci.yml`](.github/workflows/ci.yml) via [`.github/actions/appleapp-road-test`](.github/actions/appleapp-road-test/action.yml):
+
+| Job                           | E2E | Notes                                    |
+| ----------------------------- | --- | ---------------------------------------- |
+| `ios-appleapp-vanilla`        | Yes | `RNApp` → package → `AppleApp` Detox     |
+| `ios-appleapp-expo` (Expo 54) | No  | Road test only (Release build)           |
+| `ios-appleapp-expo` (Expo 55) | Yes | `ExpoApp55` → package → `AppleApp` Detox |
+
+On failure, CI uploads `apps/AppleApp/e2e-artifacts/` as a workflow artifact (`detox-appleapp-*-ios-recordings`).
+
+Direct host-app E2E is local-only — use the `ci:local:*` scripts below to reproduce CI-like setup on macOS.
+
+### Local CI scripts
+
+From the repo root (macOS + Xcode + Simulator required). All wrap `scripts/ci-local-ios-e2e-common.sh` and accept the same flags:
+
+| Command                                 | Mirrors                          |
+| --------------------------------------- | -------------------------------- |
+| `yarn ci:local:rnapp:e2e:ios`           | RN host app E2E (`apps/RNApp`)   |
+| `yarn ci:local:expo54:e2e:ios`          | Expo 54 host app E2E             |
+| `yarn ci:local:expo55:e2e:ios`          | Expo 55 host app E2E             |
+| `yarn ci:local:appleapp:e2e:ios`        | CI `ios-appleapp-vanilla`        |
+| `yarn ci:local:appleapp:e2e:ios:expo55` | CI `ios-appleapp-expo` (Expo 55) |
+
+Common flags (append to any command above):
+
+| Flag             | Effect                                                 |
+| ---------------- | ------------------------------------------------------ |
+| `--clean-ios`    | Remove `ios/Pods` and `ios/build` before setup         |
+| `--skip-install` | Skip root `yarn install` / `yarn build`                |
+| `--rebuild`      | Detox build + test only (skip install, prebuild, pods) |
+| `--test-only`    | Run tests against an existing build (no rebuild)       |
+| `--build-only`   | Detox build only, skip tests                           |
+
+Host-app scripts run `yarn install`, `yarn build`, brownfield codegen, `expo prebuild`, `pod install`, Detox postinstall, then `e2e:build:ios` and `e2e:test:ios`. The AppleApp script packages the RN app and copies XCFrameworks first (same as CI).
+
+### `e2e-artifacts/`
+
+Detox writes failure diagnostics under `<app>/e2e-artifacts/` (configured in `apps/brownfield-example-shared-tests/detox-artifacts-config.cjs`). Each run creates a timestamped subfolder, e.g. `e2e-artifacts/ios.sim.debug.<TIMESTAMP>/`.

--- a/apps/AndroidApp/app/src/main/java/com/callstack/brownfield/android/example/MainActivity.kt
+++ b/apps/AndroidApp/app/src/main/java/com/callstack/brownfield/android/example/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.callstack.brownfield.android.example
 
 import com.callstack.brownie.registerStoreIfNeeded
+import android.app.Activity
 import android.content.Intent
 import android.content.res.Configuration
 import android.os.Build
@@ -20,9 +21,11 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.fragment.compose.AndroidFragment
@@ -137,6 +140,11 @@ private fun MainScreen(modifier: Modifier = Modifier) {
 fun ReactNativeView(
     modifier: Modifier = Modifier
 ) {
+    val activity = LocalContext.current as? Activity
+    val brownfieldE2E = remember(activity) {
+        activity?.intent?.getStringExtra("DetoxE2E") == "YES"
+    }
+
     AndroidFragment<ReactNativeFragment>(
         modifier = modifier,
         arguments = Bundle().apply {
@@ -151,6 +159,7 @@ fun ReactNativeView(
                         "nativeOsVersionLabel",
                         "Android ${Build.VERSION.RELEASE}"
                     )
+                    putBoolean("brownfieldE2E", brownfieldE2E)
                 }
             )
         }

--- a/apps/AppleApp/Brownfield Apple App/components/ContentView.swift
+++ b/apps/AppleApp/Brownfield Apple App/components/ContentView.swift
@@ -34,6 +34,14 @@ private func brownfieldPostMessageText(from raw: String) -> String {
     return raw
 }
 
+private var brownfieldInitialProperties: [String: Any] {
+    [
+        "nativeOsVersionLabel":
+            "\(UIDevice.current.systemName) \(UIDevice.current.systemVersion)",
+        "brownfieldE2E": ProcessInfo.processInfo.arguments.contains("-DetoxE2E"),
+    ]
+}
+
 struct ContentView: View {
     @State private var messageObserver: NSObjectProtocol?
     @State private var showPostMessageToast = false
@@ -50,10 +58,7 @@ struct ContentView: View {
 
                         ReactNativeView(
                             moduleName: reactNativeModuleName,
-                            initialProperties: [
-                                "nativeOsVersionLabel":
-                                    "\(UIDevice.current.systemName) \(UIDevice.current.systemVersion)"
-                            ]
+                            initialProperties: brownfieldInitialProperties
                         )
                         .navigationBarHidden(true)
                         .clipShape(RoundedRectangle(cornerRadius: 16))

--- a/apps/ExpoApp54/.gitignore
+++ b/apps/ExpoApp54/.gitignore
@@ -39,7 +39,7 @@ yarn-error.*
 app-example
 
 # Detox
-artifacts/
+e2e-artifacts/
 
 # generated native folders
 /ios

--- a/apps/ExpoApp54/RNApp.tsx
+++ b/apps/ExpoApp54/RNApp.tsx
@@ -1,16 +1,27 @@
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Button, StyleSheet, Text, View } from 'react-native';
+import { useEffect } from 'react';
 import BrownfieldNavigation from '@callstack/brownfield-navigation';
+import {
+  syncBrownfieldE2EModeFromRootProps,
+  type BrownfieldRootProps,
+} from '@callstack/brownfield-example-shared-tests';
 
 import Counter from './components/counter';
 
 import { checkAndFetchUpdate } from './utils/expo-rn-updates';
 
-type RNAppProps = {
-  nativeOsVersionLabel?: string;
-};
+type RNAppProps = BrownfieldRootProps;
 
-export default function RNApp({ nativeOsVersionLabel }: RNAppProps) {
+export default function RNApp({
+  nativeOsVersionLabel,
+  brownfieldE2E,
+}: RNAppProps) {
+  useEffect(() => {
+    syncBrownfieldE2EModeFromRootProps({ brownfieldE2E });
+    return () => syncBrownfieldE2EModeFromRootProps(undefined);
+  }, [brownfieldE2E]);
+
   return (
     <SafeAreaView style={styles.container}>
       <Text style={styles.title}>Expo React Native Brownfield</Text>

--- a/apps/ExpoApp54/RNApp.tsx
+++ b/apps/ExpoApp54/RNApp.tsx
@@ -5,7 +5,7 @@ import BrownfieldNavigation from '@callstack/brownfield-navigation';
 import {
   syncBrownfieldE2EModeFromRootProps,
   type BrownfieldRootProps,
-} from '@callstack/brownfield-example-shared-tests';
+} from '@callstack/brownfield-example-shared-tests/runtime';
 
 import Counter from './components/counter';
 

--- a/apps/ExpoApp54/RNApp.tsx
+++ b/apps/ExpoApp54/RNApp.tsx
@@ -18,7 +18,7 @@ export default function RNApp({
   brownfieldE2E,
 }: RNAppProps) {
   useEffect(() => {
-    syncBrownfieldE2EModeFromRootProps({ brownfieldE2E });
+    syncBrownfieldE2EModeFromRootProps(brownfieldE2E);
     return () => syncBrownfieldE2EModeFromRootProps(undefined);
   }, [brownfieldE2E]);
 

--- a/apps/ExpoApp54/app/(tabs)/postMessage.tsx
+++ b/apps/ExpoApp54/app/(tabs)/postMessage.tsx
@@ -1,7 +1,7 @@
 import { StyleSheet, FlatList, TouchableOpacity } from 'react-native';
 
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { brownfieldE2eTestIds } from '@callstack/brownfield-example-shared-tests/e2eTestIds';
+import { brownfieldE2ETestIds } from '@callstack/brownfield-example-shared-tests/e2eTestIds';
 import ReactNativeBrownfield from '@callstack/react-native-brownfield';
 import type { MessageEvent } from '@callstack/react-native-brownfield';
 
@@ -52,7 +52,7 @@ export default function PostMessageTab() {
   return (
     <ThemedView style={styles.messageSection}>
       <TouchableOpacity
-        testID={brownfieldE2eTestIds.sendMessageToNative}
+        testID={brownfieldE2ETestIds.sendMessageToNative}
         style={styles.sendButton}
         onPress={sendMessage}
         activeOpacity={0.8}

--- a/apps/ExpoApp54/components/postMessage/MessageBubble.tsx
+++ b/apps/ExpoApp54/components/postMessage/MessageBubble.tsx
@@ -1,7 +1,7 @@
 import { Animated, StyleSheet } from 'react-native';
 import { Message } from './Message';
 import { useEffect, useRef } from 'react';
-import { brownfieldE2eTestIds } from '@callstack/brownfield-example-shared-tests/e2eTestIds';
+import { brownfieldE2ETestIds } from '@callstack/brownfield-example-shared-tests/e2eTestIds';
 import { ThemedText } from '@/components/themed-text';
 
 export function MessageBubble({ item }: { item: Message }) {
@@ -44,7 +44,7 @@ export function MessageBubble({ item }: { item: Message }) {
       <ThemedText
         style={styles.bubbleText}
         testID={
-          isFromNative ? undefined : brownfieldE2eTestIds.rnPostMessageText
+          isFromNative ? undefined : brownfieldE2ETestIds.rnPostMessageText
         }
       >
         {item.text}

--- a/apps/ExpoApp54/entry.tsx
+++ b/apps/ExpoApp54/entry.tsx
@@ -8,7 +8,7 @@ import {
 
 function App(props: BrownfieldRootProps) {
   useEffect(() => {
-    syncBrownfieldE2EModeFromRootProps(props);
+    syncBrownfieldE2EModeFromRootProps(props.brownfieldE2E);
     return () => syncBrownfieldE2EModeFromRootProps(undefined);
   }, [props.brownfieldE2E]);
 

--- a/apps/ExpoApp54/entry.tsx
+++ b/apps/ExpoApp54/entry.tsx
@@ -1,7 +1,17 @@
 import { ExpoRoot } from 'expo-router';
+import { useEffect } from 'react';
 import { AppRegistry } from 'react-native';
+import {
+  syncBrownfieldE2EModeFromRootProps,
+  type BrownfieldRootProps,
+} from '@callstack/brownfield-example-shared-tests';
 
-function App() {
+function App(props: BrownfieldRootProps) {
+  useEffect(() => {
+    syncBrownfieldE2EModeFromRootProps(props);
+    return () => syncBrownfieldE2EModeFromRootProps(undefined);
+  }, [props.brownfieldE2E]);
+
   const ctx = require.context('./app');
   return <ExpoRoot context={ctx} />;
 }

--- a/apps/ExpoApp54/entry.tsx
+++ b/apps/ExpoApp54/entry.tsx
@@ -4,7 +4,7 @@ import { AppRegistry } from 'react-native';
 import {
   syncBrownfieldE2EModeFromRootProps,
   type BrownfieldRootProps,
-} from '@callstack/brownfield-example-shared-tests';
+} from '@callstack/brownfield-example-shared-tests/runtime';
 
 function App(props: BrownfieldRootProps) {
   useEffect(() => {

--- a/apps/ExpoApp54/utils/expo-rn-updates.ts
+++ b/apps/ExpoApp54/utils/expo-rn-updates.ts
@@ -1,5 +1,5 @@
+import { userAlert } from '@callstack/brownfield-example-shared-tests';
 import * as Updates from 'expo-updates';
-import { Alert } from 'react-native';
 
 export async function checkAndFetchUpdate() {
   try {
@@ -17,9 +17,9 @@ export async function checkAndFetchUpdate() {
         },
       });
     } else {
-      Alert.alert('No update available');
+      userAlert('No update available');
     }
   } catch (error) {
-    Alert.alert('Update check failed', String(error));
+    userAlert('Update check failed', String(error));
   }
 }

--- a/apps/ExpoApp54/utils/expo-rn-updates.ts
+++ b/apps/ExpoApp54/utils/expo-rn-updates.ts
@@ -1,4 +1,4 @@
-import { userAlert } from '@callstack/brownfield-example-shared-tests';
+import { userAlert } from '@callstack/brownfield-example-shared-tests/runtime';
 import * as Updates from 'expo-updates';
 
 export async function checkAndFetchUpdate() {

--- a/apps/ExpoApp55/.gitignore
+++ b/apps/ExpoApp55/.gitignore
@@ -39,7 +39,7 @@ yarn-error.*
 app-example
 
 # Detox
-artifacts/
+e2e-artifacts/
 
 # generated native folders
 /ios

--- a/apps/ExpoApp55/RNApp.tsx
+++ b/apps/ExpoApp55/RNApp.tsx
@@ -17,7 +17,7 @@ export default function RNApp({
   brownfieldE2E,
 }: RNAppProps) {
   useEffect(() => {
-    syncBrownfieldE2EModeFromRootProps({ brownfieldE2E });
+    syncBrownfieldE2EModeFromRootProps(brownfieldE2E);
     return () => syncBrownfieldE2EModeFromRootProps(undefined);
   }, [brownfieldE2E]);
 

--- a/apps/ExpoApp55/RNApp.tsx
+++ b/apps/ExpoApp55/RNApp.tsx
@@ -1,15 +1,26 @@
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Button, StyleSheet, Text, View } from 'react-native';
+import { useEffect } from 'react';
 import BrownfieldNavigation from '@callstack/brownfield-navigation';
+import {
+  syncBrownfieldE2EModeFromRootProps,
+  type BrownfieldRootProps,
+} from '@callstack/brownfield-example-shared-tests';
 import { checkAndFetchUpdate } from './src/utils/expo-rn-updates';
 
 import Counter from './src/components/counter';
 
-type RNAppProps = {
-  nativeOsVersionLabel?: string;
-};
+type RNAppProps = BrownfieldRootProps;
 
-export default function RNApp({ nativeOsVersionLabel }: RNAppProps) {
+export default function RNApp({
+  nativeOsVersionLabel,
+  brownfieldE2E,
+}: RNAppProps) {
+  useEffect(() => {
+    syncBrownfieldE2EModeFromRootProps({ brownfieldE2E });
+    return () => syncBrownfieldE2EModeFromRootProps(undefined);
+  }, [brownfieldE2E]);
+
   return (
     <SafeAreaView style={styles.container}>
       <Text style={styles.title}>Expo React Native Brownfield</Text>

--- a/apps/ExpoApp55/RNApp.tsx
+++ b/apps/ExpoApp55/RNApp.tsx
@@ -5,7 +5,7 @@ import BrownfieldNavigation from '@callstack/brownfield-navigation';
 import {
   syncBrownfieldE2EModeFromRootProps,
   type BrownfieldRootProps,
-} from '@callstack/brownfield-example-shared-tests';
+} from '@callstack/brownfield-example-shared-tests/runtime';
 import { checkAndFetchUpdate } from './src/utils/expo-rn-updates';
 
 import Counter from './src/components/counter';

--- a/apps/ExpoApp55/__tests__/brownfield.example.test.tsx
+++ b/apps/ExpoApp55/__tests__/brownfield.example.test.tsx
@@ -5,8 +5,10 @@ import {
   runPostMessageTabSuite,
   runCounterSuite,
   runExpoRnAppSuite,
+  runUserAlertSuite,
 } from '@callstack/brownfield-example-shared-tests';
 
 runPostMessageTabSuite('ExpoApp55', PostMessageTab);
 runCounterSuite('ExpoApp55', Counter);
 runExpoRnAppSuite('ExpoApp55', RNApp);
+runUserAlertSuite('ExpoApp55');

--- a/apps/ExpoApp55/entry.tsx
+++ b/apps/ExpoApp55/entry.tsx
@@ -4,7 +4,7 @@ import { AppRegistry } from 'react-native';
 import {
   syncBrownfieldE2EModeFromRootProps,
   type BrownfieldRootProps,
-} from '@callstack/brownfield-example-shared-tests';
+} from '@callstack/brownfield-example-shared-tests/runtime';
 
 function App(props: BrownfieldRootProps) {
   useEffect(() => {

--- a/apps/ExpoApp55/entry.tsx
+++ b/apps/ExpoApp55/entry.tsx
@@ -1,7 +1,17 @@
 import { ExpoRoot } from 'expo-router';
+import { useEffect } from 'react';
 import { AppRegistry } from 'react-native';
+import {
+  syncBrownfieldE2EModeFromRootProps,
+  type BrownfieldRootProps,
+} from '@callstack/brownfield-example-shared-tests';
 
-function App() {
+function App(props: BrownfieldRootProps) {
+  useEffect(() => {
+    syncBrownfieldE2EModeFromRootProps(props.brownfieldE2E);
+    return () => syncBrownfieldE2EModeFromRootProps(undefined);
+  }, [props.brownfieldE2E]);
+
   const ctx = require.context('./src/app');
   return <ExpoRoot context={ctx} />;
 }

--- a/apps/ExpoApp55/src/app/postMessage.tsx
+++ b/apps/ExpoApp55/src/app/postMessage.tsx
@@ -1,7 +1,7 @@
 import { StyleSheet, FlatList, TouchableOpacity } from 'react-native';
 
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { brownfieldE2eTestIds } from '@callstack/brownfield-example-shared-tests/e2eTestIds';
+import { brownfieldE2ETestIds } from '@callstack/brownfield-example-shared-tests/e2eTestIds';
 import ReactNativeBrownfield from '@callstack/react-native-brownfield';
 import type { MessageEvent } from '@callstack/react-native-brownfield';
 
@@ -52,7 +52,7 @@ export default function PostMessageTab() {
   return (
     <ThemedView style={styles.messageSection}>
       <TouchableOpacity
-        testID={brownfieldE2eTestIds.sendMessageToNative}
+        testID={brownfieldE2ETestIds.sendMessageToNative}
         style={styles.sendButton}
         onPress={sendMessage}
         activeOpacity={0.8}

--- a/apps/ExpoApp55/src/components/postMessage/MessageBubble.tsx
+++ b/apps/ExpoApp55/src/components/postMessage/MessageBubble.tsx
@@ -1,7 +1,7 @@
 import { Animated, StyleSheet } from 'react-native';
 import { Message } from './Message';
 import { useEffect, useRef } from 'react';
-import { brownfieldE2eTestIds } from '@callstack/brownfield-example-shared-tests/e2eTestIds';
+import { brownfieldE2ETestIds } from '@callstack/brownfield-example-shared-tests/e2eTestIds';
 import { ThemedText } from '@/components/themed-text';
 
 export function MessageBubble({ item }: { item: Message }) {
@@ -44,7 +44,7 @@ export function MessageBubble({ item }: { item: Message }) {
       <ThemedText
         style={styles.bubbleText}
         testID={
-          isFromNative ? undefined : brownfieldE2eTestIds.rnPostMessageText
+          isFromNative ? undefined : brownfieldE2ETestIds.rnPostMessageText
         }
       >
         {item.text}

--- a/apps/ExpoApp55/src/utils/expo-rn-updates.ts
+++ b/apps/ExpoApp55/src/utils/expo-rn-updates.ts
@@ -1,5 +1,5 @@
+import { userAlert } from '@callstack/brownfield-example-shared-tests';
 import * as Updates from 'expo-updates';
-import { Alert } from 'react-native';
 
 export async function checkAndFetchUpdate() {
   try {
@@ -17,9 +17,9 @@ export async function checkAndFetchUpdate() {
         },
       });
     } else {
-      Alert.alert('No update available');
+      userAlert('No update available');
     }
   } catch (error) {
-    Alert.alert('Update check failed', String(error));
+    userAlert('Update check failed', String(error));
   }
 }

--- a/apps/ExpoApp55/src/utils/expo-rn-updates.ts
+++ b/apps/ExpoApp55/src/utils/expo-rn-updates.ts
@@ -1,4 +1,4 @@
-import { userAlert } from '@callstack/brownfield-example-shared-tests';
+import { userAlert } from '@callstack/brownfield-example-shared-tests/runtime';
 import * as Updates from 'expo-updates';
 
 export async function checkAndFetchUpdate() {

--- a/apps/RNApp/jest.config.js
+++ b/apps/RNApp/jest.config.js
@@ -7,6 +7,7 @@ module.exports = {
     '^react$': require.resolve('react'),
     '^react/jsx-runtime$': require.resolve('react/jsx-runtime'),
     '^react/jsx-dev-runtime$': require.resolve('react/jsx-dev-runtime'),
+    '^react-native$': require.resolve('react-native'),
     '^@testing-library/react-native$':
       require.resolve('@testing-library/react-native'),
     '^@callstack/react-native-brownfield$': path.join(

--- a/apps/RNApp/src/App.tsx
+++ b/apps/RNApp/src/App.tsx
@@ -15,7 +15,7 @@ type AppProps = BrownfieldRootProps;
 
 export default function App({ nativeOsVersionLabel, brownfieldE2E }: AppProps) {
   useEffect(() => {
-    syncBrownfieldE2EModeFromRootProps({ brownfieldE2E });
+    syncBrownfieldE2EModeFromRootProps(brownfieldE2E);
     return () => syncBrownfieldE2EModeFromRootProps(undefined);
   }, [brownfieldE2E]);
 

--- a/apps/RNApp/src/App.tsx
+++ b/apps/RNApp/src/App.tsx
@@ -5,7 +5,7 @@ import { useEffect } from 'react';
 import {
   syncBrownfieldE2EModeFromRootProps,
   type BrownfieldRootProps,
-} from '@callstack/brownfield-example-shared-tests';
+} from '@callstack/brownfield-example-shared-tests/runtime';
 
 import { HomeScreen } from './HomeScreen';
 import { NativeOsVersionLabelContext } from './nativeHostContext';

--- a/apps/RNApp/src/App.tsx
+++ b/apps/RNApp/src/App.tsx
@@ -1,16 +1,24 @@
 import '../BrownfieldStore.brownie';
 
 import { NavigationContainer } from '@react-navigation/native';
+import { useEffect } from 'react';
+import {
+  syncBrownfieldE2EModeFromRootProps,
+  type BrownfieldRootProps,
+} from '@callstack/brownfield-example-shared-tests';
 
 import { HomeScreen } from './HomeScreen';
 import { NativeOsVersionLabelContext } from './nativeHostContext';
 import { Stack } from './navigation/RootStack';
 
-type AppProps = {
-  nativeOsVersionLabel?: string;
-};
+type AppProps = BrownfieldRootProps;
 
-export default function App({ nativeOsVersionLabel }: AppProps) {
+export default function App({ nativeOsVersionLabel, brownfieldE2E }: AppProps) {
+  useEffect(() => {
+    syncBrownfieldE2EModeFromRootProps({ brownfieldE2E });
+    return () => syncBrownfieldE2EModeFromRootProps(undefined);
+  }, [brownfieldE2E]);
+
   return (
     <NativeOsVersionLabelContext.Provider value={nativeOsVersionLabel}>
       <NavigationContainer>

--- a/apps/RNApp/src/HomeScreen.tsx
+++ b/apps/RNApp/src/HomeScreen.tsx
@@ -10,7 +10,7 @@ import {
 } from 'react-native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import ReactNativeBrownfield from '@callstack/react-native-brownfield';
-import { brownfieldE2eTestIds } from '@callstack/brownfield-example-shared-tests/e2eTestIds';
+import { brownfieldE2ETestIds } from '@callstack/brownfield-example-shared-tests/e2eTestIds';
 import BrownfieldNavigation from '@callstack/brownfield-navigation';
 
 import { getRandomTheme } from './utils';
@@ -64,7 +64,7 @@ function MessageBubble({ item, color }: { item: Message; color: string }) {
       </Text>
       <Text
         testID={
-          isFromNative ? undefined : brownfieldE2eTestIds.rnPostMessageText
+          isFromNative ? undefined : brownfieldE2ETestIds.rnPostMessageText
         }
         style={styles.bubbleText}
       >
@@ -128,11 +128,11 @@ export function HomeScreen({
 
   return (
     <View
-      testID={brownfieldE2eTestIds.rnAppHome}
+      testID={brownfieldE2ETestIds.rnAppHome}
       style={[styles.container, { backgroundColor: colors.primary }]}
     >
       <Text
-        testID={brownfieldE2eTestIds.rnAppHomeTitle}
+        testID={brownfieldE2ETestIds.rnAppHomeTitle}
         accessibilityLabel="React Native Screen"
         style={[styles.text, { color: colors.secondary }]}
       >
@@ -152,7 +152,7 @@ export function HomeScreen({
 
       <View style={styles.nativeNavButtons}>
         <Button
-          testID={brownfieldE2eTestIds.openNativeSettings}
+          testID={brownfieldE2ETestIds.openNativeSettings}
           onPress={() =>
             BrownfieldNavigation.navigateToSettings({
               id: '123',
@@ -170,7 +170,7 @@ export function HomeScreen({
         />
 
         <Button
-          testID={brownfieldE2eTestIds.openNativeReferrals}
+          testID={brownfieldE2ETestIds.openNativeReferrals}
           onPress={() => BrownfieldNavigation.navigateToReferrals('user-123')}
           color={colors.secondary}
           title="Open native referrals"
@@ -179,7 +179,7 @@ export function HomeScreen({
 
       <View style={styles.messageSection}>
         <TouchableOpacity
-          testID={brownfieldE2eTestIds.sendMessageToNative}
+          testID={brownfieldE2ETestIds.sendMessageToNative}
           style={[styles.sendButton, { backgroundColor: colors.secondary }]}
           onPress={sendMessage}
           activeOpacity={0.8}

--- a/apps/RNApp/src/components/counter/index.tsx
+++ b/apps/RNApp/src/components/counter/index.tsx
@@ -1,4 +1,4 @@
-import { brownfieldE2eTestIds } from '@callstack/brownfield-example-shared-tests/e2eTestIds';
+import { brownfieldE2ETestIds } from '@callstack/brownfield-example-shared-tests/e2eTestIds';
 import { Button, StyleSheet, Text } from 'react-native';
 import { useStore } from '@callstack/brownie';
 
@@ -12,7 +12,7 @@ const Counter = ({ colors }: CounterProps) => {
   return (
     <>
       <Text
-        testID={brownfieldE2eTestIds.counterCount}
+        testID={brownfieldE2ETestIds.counterCount}
         accessibilityLabel={`Count: ${counter}`}
         style={[styles.text, { color: colors.secondary }]}
       >
@@ -20,7 +20,7 @@ const Counter = ({ colors }: CounterProps) => {
       </Text>
 
       <Button
-        testID={brownfieldE2eTestIds.counterIncrement}
+        testID={brownfieldE2ETestIds.counterIncrement}
         onPress={() => setState((prev) => ({ counter: prev.counter + 1 }))}
         color={colors.secondary}
         title="Increment"

--- a/apps/brownfield-example-shared-tests/e2e/appleAppBrownfield.e2e.js
+++ b/apps/brownfield-example-shared-tests/e2e/appleAppBrownfield.e2e.js
@@ -5,7 +5,7 @@ const {
 const {
   assertDetoxTextMatches,
   launchBrownfieldAppForDetox,
-  waitForVisibleIgnoringSync,
+  waitForNativeOverlayVisible,
 } = require('@callstack/brownfield-example-shared-tests/e2e/detoxUtils');
 const {
   scrollToNativeShellVanilla,
@@ -42,11 +42,11 @@ describe('Brownfield (AppleApp — Vanilla)', () => {
 
   it('navigates to native settings from the RN surface', async () => {
     await element(by.id(ids.openNativeSettings)).tap();
-    await waitForVisibleIgnoringSync(by.label('Settings'), 10000);
+    await waitForNativeOverlayVisible(by.label('Settings'), 10000);
   });
 
   it('navigates to native referrals from the RN surface', async () => {
     await element(by.id(ids.openNativeReferrals)).tap();
-    await waitForVisibleIgnoringSync(by.label('Referrals'), 10000, 0);
+    await waitForNativeOverlayVisible(by.label('Referrals'), 10000, 0);
   });
 });

--- a/apps/brownfield-example-shared-tests/e2e/appleAppBrownfield.e2e.js
+++ b/apps/brownfield-example-shared-tests/e2e/appleAppBrownfield.e2e.js
@@ -1,15 +1,13 @@
-const { device, element, by, expect: detoxExpect } = require('detox');
+const { element, by, expect: detoxExpect } = require('detox');
 const {
   brownfieldE2ETestIds: ids,
 } = require('@callstack/brownfield-example-shared-tests/e2e/e2eTestIds');
 const {
   assertDetoxTextMatches,
-  configureDetoxForBrownfieldIos,
+  launchBrownfieldAppForDetox,
   waitForVisibleIgnoringSync,
 } = require('@callstack/brownfield-example-shared-tests/e2e/detoxUtils');
 const {
-  detoxLaunchArgs,
-  scrollToEmbeddedRnVanilla,
   scrollToNativeShellVanilla,
   waitForAppleAppReadyVanilla,
   sendPostMessageToNativeAndWaitForToast,
@@ -17,11 +15,7 @@ const {
 
 describe('Brownfield (AppleApp — Vanilla)', () => {
   beforeEach(async () => {
-    await device.launchApp({
-      newInstance: true,
-      launchArgs: detoxLaunchArgs,
-    });
-    await configureDetoxForBrownfieldIos();
+    await launchBrownfieldAppForDetox({ newInstance: true });
     await waitForAppleAppReadyVanilla();
   });
 

--- a/apps/brownfield-example-shared-tests/e2e/appleAppBrownfield.e2e.js
+++ b/apps/brownfield-example-shared-tests/e2e/appleAppBrownfield.e2e.js
@@ -1,5 +1,7 @@
 const { device, element, by, expect: detoxExpect } = require('detox');
-const { brownfieldE2eTestIds: ids } = require('@callstack/brownfield-example-shared-tests/e2e/e2eTestIds');
+const {
+  brownfieldE2ETestIds: ids,
+} = require('@callstack/brownfield-example-shared-tests/e2e/e2eTestIds');
 const {
   assertDetoxTextMatches,
   configureDetoxForBrownfieldIos,

--- a/apps/brownfield-example-shared-tests/e2e/appleAppDetoxUtils.cjs
+++ b/apps/brownfield-example-shared-tests/e2e/appleAppDetoxUtils.cjs
@@ -1,21 +1,17 @@
 const { element, by } = require('detox');
 const {
-  brownfieldE2eTestIds: ids,
+  brownfieldE2ETestIds: ids,
 } = require('@callstack/brownfield-example-shared-tests/e2e/e2eTestIds');
 const { DETOX_TIMING } = require('./detoxTiming.cjs');
 const {
   assertDetoxTextMatches,
+  detoxLaunchArgs,
   reloadReactNativeIgnoringSync,
   waitForVisibleIgnoringSync,
 } = require('@callstack/brownfield-example-shared-tests/e2e/detoxUtils');
 
 const EXPO_HOME_TAB = by.label('Home');
 const EXPO_WELCOME_TITLE = by.text(/Welcome to\s+Expo\s+55/);
-
-const detoxLaunchArgs = {
-  BrownfieldPreferEmbeddedBundleInDebug: 'YES',
-  DetoxE2E: 'YES',
-};
 
 async function scrollToEmbeddedRnVanilla() {
   try {

--- a/apps/brownfield-example-shared-tests/e2e/appleAppDetoxUtils.cjs
+++ b/apps/brownfield-example-shared-tests/e2e/appleAppDetoxUtils.cjs
@@ -1,9 +1,14 @@
-const { device, element, by, waitFor } = require('detox');
+const { device, element, by } = require('detox');
 const { brownfieldE2eTestIds: ids } = require('@callstack/brownfield-example-shared-tests/e2e/e2eTestIds');
+const { DETOX_TIMING } = require('@callstack/brownfield-example-shared-tests/e2e/detoxTiming.cjs');
 const {
   assertDetoxTextMatches,
+  reloadReactNativeIgnoringSync,
   waitForVisibleIgnoringSync,
 } = require('@callstack/brownfield-example-shared-tests/e2e/detoxUtils');
+
+const EXPO_HOME_TAB = by.label('Home');
+const EXPO_WELCOME_TITLE = by.text(/Welcome to\s+Expo\s+55/);
 
 const detoxLaunchArgs = {
   BrownfieldPreferEmbeddedBundleInDebug: 'YES',
@@ -26,7 +31,7 @@ async function scrollToEmbeddedRnExpo() {
     try {
       await scrollView.scrollTo('bottom');
     } catch {
-      await element(by.label('Home')).swipe('up', 'fast', 0.85);
+      await element(EXPO_HOME_TAB).atIndex(0).swipe('up', 'fast', 0.85);
     }
   }
 }
@@ -43,98 +48,124 @@ async function scrollToNativeShellExpo() {
   try {
     await element(by.type('UIScrollView')).atIndex(0).scrollTo('top');
   } catch {
-    await element(by.label('Home')).swipe('down', 'fast', 0.85);
+    await element(EXPO_HOME_TAB).atIndex(0).swipe('down', 'fast', 0.85);
   }
+}
+
+async function waitForEmbeddedMatcher(matcher, index = 0) {
+  try {
+    await scrollToEmbeddedRnExpo();
+  } catch {
+    // Embedded RN may already be on screen.
+  }
+
+  try {
+    await waitForVisibleIgnoringSync(
+      matcher,
+      DETOX_TIMING.VISIBILITY_TIMEOUT_MS,
+      index
+    );
+    return;
+  } catch {
+    // Continue with reload recovery.
+  }
+
+  await reloadReactNativeIgnoringSync();
+
+  try {
+    await scrollToEmbeddedRnExpo();
+  } catch {
+    // Continue polling visibility.
+  }
+
+  await waitForVisibleIgnoringSync(
+    matcher,
+    DETOX_TIMING.VISIBILITY_TIMEOUT_MS,
+    index
+  );
 }
 
 async function waitForAppleAppReadyVanilla() {
   const rnHomeMatcher = by.id(ids.rnAppHome);
-  const rnHome = element(rnHomeMatcher);
+
   try {
-    await waitForVisibleIgnoringSync(rnHomeMatcher, 30000);
+    await scrollToEmbeddedRnVanilla();
   } catch {
-    // Some CI runs start with an unmounted RN surface; one reload usually recovers.
-    await device.reloadReactNative();
-    try {
-      await waitForVisibleIgnoringSync(rnHomeMatcher, 30000);
-      return;
-    } catch {
-      // Embedded RN may be off-screen in the native scroll view.
-    }
-    await device.disableSynchronization();
-    try {
-      await scrollToEmbeddedRnVanilla();
-      await waitFor(rnHome).toBeVisible().withTimeout(20000);
-    } finally {
-      await device.enableSynchronization();
-    }
+    // Continue polling visibility.
   }
+
+  try {
+    await waitForVisibleIgnoringSync(
+      rnHomeMatcher,
+      DETOX_TIMING.VISIBILITY_TIMEOUT_MS
+    );
+    return;
+  } catch {
+    // Continue with reload recovery.
+  }
+
+  await reloadReactNativeIgnoringSync();
+
+  try {
+    await scrollToEmbeddedRnVanilla();
+  } catch {
+    // Continue polling visibility.
+  }
+
+  await waitForVisibleIgnoringSync(
+    rnHomeMatcher,
+    DETOX_TIMING.VISIBILITY_TIMEOUT_MS
+  );
 }
 
 async function waitForAppleAppReadyExpo() {
-  const homeTab = by.label('Home');
-  const homeElement = () => element(homeTab).atIndex(0);
-  const welcomeTitle = by.text(/Welcome to\s+Expo\s+55/);
   try {
-    await waitForVisibleIgnoringSync(homeTab, 30000, 0);
+    await waitForEmbeddedMatcher(EXPO_HOME_TAB, 0);
     return;
   } catch {
-    // Some CI runs start with an unmounted RN surface; one reload usually recovers.
+    // Home tab can be off-screen or slow; welcome title is a reliable fallback.
   }
 
-  await device.reloadReactNative();
-  try {
-    await waitForVisibleIgnoringSync(homeTab, 30000, 0);
-    return;
-  } catch {
-    // Embedded RN may be off-screen in the native scroll view.
-  }
-
-  await device.disableSynchronization();
-  try {
-    for (let attempt = 0; attempt < 3; attempt += 1) {
-      try {
-        await scrollToEmbeddedRnExpo();
-      } catch {}
-
-      try {
-        await waitFor(homeElement()).toBeVisible().withTimeout(10000);
-        return;
-      } catch {}
-
-      try {
-        await waitFor(element(welcomeTitle)).toBeVisible().withTimeout(10000);
-        return;
-      } catch {}
-    }
-
-    await waitFor(homeElement()).toBeVisible().withTimeout(10000);
-  } finally {
-    await device.enableSynchronization();
-  }
+  await waitForEmbeddedMatcher(EXPO_WELCOME_TITLE);
 }
 
 async function openPostMessageTabExpo() {
-  await waitForVisibleIgnoringSync(by.label('postMessage API'), 30000, 0);
+  await scrollToEmbeddedRnExpo();
+  await waitForVisibleIgnoringSync(
+    by.label('postMessage API'),
+    DETOX_TIMING.VISIBILITY_TIMEOUT_MS,
+    0
+  );
   await element(by.label('postMessage API')).atIndex(0).tap();
-  await waitForVisibleIgnoringSync(by.id(ids.sendMessageToNative), 30000);
+  await waitForVisibleIgnoringSync(
+    by.id(ids.sendMessageToNative),
+    DETOX_TIMING.VISIBILITY_TIMEOUT_MS
+  );
 }
 
 async function sendPostMessageToNativeAndWaitForToast(rnMessagePattern) {
-  await waitForVisibleIgnoringSync(by.id(ids.sendMessageToNative), 30000);
+  await waitForVisibleIgnoringSync(
+    by.id(ids.sendMessageToNative),
+    DETOX_TIMING.VISIBILITY_TIMEOUT_MS
+  );
   await element(by.id(ids.sendMessageToNative)).tap();
   const bubble = element(by.id(ids.rnPostMessageText)).atIndex(0);
-  const deadline = Date.now() + 15000;
+  const deadline = Date.now() + DETOX_TIMING.POST_MESSAGE_BUBBLE_TIMEOUT_MS;
   while (Date.now() < deadline) {
     try {
       await assertDetoxTextMatches(bubble, rnMessagePattern);
       break;
     } catch {
-      await new Promise((resolve) => setTimeout(resolve, 200));
+      await new Promise((resolve) =>
+        setTimeout(resolve, DETOX_TIMING.POLL_INTERVAL_MS)
+      );
     }
   }
   await assertDetoxTextMatches(bubble, rnMessagePattern);
-  await waitForVisibleIgnoringSync(by.id(ids.appleAppPostMessageToast), 10000);
+  await waitForVisibleIgnoringSync(
+    by.id(ids.appleAppPostMessageToast),
+    DETOX_TIMING.TOAST_VISIBILITY_TIMEOUT_MS
+  );
 }
 
 module.exports = {

--- a/apps/brownfield-example-shared-tests/e2e/appleAppDetoxUtils.cjs
+++ b/apps/brownfield-example-shared-tests/e2e/appleAppDetoxUtils.cjs
@@ -1,4 +1,4 @@
-const { element, by } = require('detox');
+const { device, element, by } = require('detox');
 const {
   brownfieldE2ETestIds: ids,
 } = require('@callstack/brownfield-example-shared-tests/e2e/e2eTestIds');
@@ -6,8 +6,8 @@ const { DETOX_TIMING } = require('./detoxTiming.cjs');
 const {
   assertDetoxTextMatches,
   detoxLaunchArgs,
-  reloadReactNativeIgnoringSync,
-  waitForVisibleIgnoringSync,
+  waitForVisible,
+  waitForNativeOverlayVisible,
 } = require('@callstack/brownfield-example-shared-tests/e2e/detoxUtils');
 
 const EXPO_HOME_TAB = by.label('Home');
@@ -58,17 +58,13 @@ async function waitForEmbeddedMatcher(matcher, index = 0) {
   }
 
   try {
-    await waitForVisibleIgnoringSync(
-      matcher,
-      DETOX_TIMING.VISIBILITY_TIMEOUT_MS,
-      index
-    );
+    await waitForVisible(matcher, DETOX_TIMING.VISIBILITY_TIMEOUT_MS, index);
     return;
   } catch {
     // Continue with reload recovery.
   }
 
-  await reloadReactNativeIgnoringSync();
+  await device.reloadReactNative();
 
   try {
     await scrollToEmbeddedRnExpo();
@@ -76,11 +72,7 @@ async function waitForEmbeddedMatcher(matcher, index = 0) {
     // Continue polling visibility.
   }
 
-  await waitForVisibleIgnoringSync(
-    matcher,
-    DETOX_TIMING.VISIBILITY_TIMEOUT_MS,
-    index
-  );
+  await waitForVisible(matcher, DETOX_TIMING.VISIBILITY_TIMEOUT_MS, index);
 }
 
 async function waitForAppleAppReadyVanilla() {
@@ -93,16 +85,13 @@ async function waitForAppleAppReadyVanilla() {
   }
 
   try {
-    await waitForVisibleIgnoringSync(
-      rnHomeMatcher,
-      DETOX_TIMING.VISIBILITY_TIMEOUT_MS
-    );
+    await waitForVisible(rnHomeMatcher, DETOX_TIMING.VISIBILITY_TIMEOUT_MS);
     return;
   } catch {
     // Continue with reload recovery.
   }
 
-  await reloadReactNativeIgnoringSync();
+  await device.reloadReactNative();
 
   try {
     await scrollToEmbeddedRnVanilla();
@@ -110,10 +99,7 @@ async function waitForAppleAppReadyVanilla() {
     // Continue polling visibility.
   }
 
-  await waitForVisibleIgnoringSync(
-    rnHomeMatcher,
-    DETOX_TIMING.VISIBILITY_TIMEOUT_MS
-  );
+  await waitForVisible(rnHomeMatcher, DETOX_TIMING.VISIBILITY_TIMEOUT_MS);
 }
 
 async function waitForAppleAppReadyExpo() {
@@ -129,20 +115,20 @@ async function waitForAppleAppReadyExpo() {
 
 async function openPostMessageTabExpo() {
   await scrollToEmbeddedRnExpo();
-  await waitForVisibleIgnoringSync(
+  await waitForVisible(
     by.label('postMessage API'),
     DETOX_TIMING.VISIBILITY_TIMEOUT_MS,
     0
   );
   await element(by.label('postMessage API')).atIndex(0).tap();
-  await waitForVisibleIgnoringSync(
+  await waitForVisible(
     by.id(ids.sendMessageToNative),
     DETOX_TIMING.VISIBILITY_TIMEOUT_MS
   );
 }
 
 async function sendPostMessageToNativeAndWaitForToast(rnMessagePattern) {
-  await waitForVisibleIgnoringSync(
+  await waitForVisible(
     by.id(ids.sendMessageToNative),
     DETOX_TIMING.VISIBILITY_TIMEOUT_MS
   );
@@ -160,7 +146,7 @@ async function sendPostMessageToNativeAndWaitForToast(rnMessagePattern) {
     }
   }
   await assertDetoxTextMatches(bubble, rnMessagePattern);
-  await waitForVisibleIgnoringSync(
+  await waitForNativeOverlayVisible(
     by.id(ids.appleAppPostMessageToast),
     DETOX_TIMING.TOAST_VISIBILITY_TIMEOUT_MS
   );

--- a/apps/brownfield-example-shared-tests/e2e/appleAppDetoxUtils.cjs
+++ b/apps/brownfield-example-shared-tests/e2e/appleAppDetoxUtils.cjs
@@ -1,6 +1,8 @@
-const { device, element, by } = require('detox');
-const { brownfieldE2eTestIds: ids } = require('@callstack/brownfield-example-shared-tests/e2e/e2eTestIds');
-const { DETOX_TIMING } = require('@callstack/brownfield-example-shared-tests/e2e/detoxTiming.cjs');
+const { element, by } = require('detox');
+const {
+  brownfieldE2eTestIds: ids,
+} = require('@callstack/brownfield-example-shared-tests/e2e/e2eTestIds');
+const { DETOX_TIMING } = require('./detoxTiming.cjs');
 const {
   assertDetoxTextMatches,
   reloadReactNativeIgnoringSync,

--- a/apps/brownfield-example-shared-tests/e2e/appleAppExpoBrownfield.e2e.js
+++ b/apps/brownfield-example-shared-tests/e2e/appleAppExpoBrownfield.e2e.js
@@ -1,5 +1,7 @@
 const { device, element, by, expect: detoxExpect } = require('detox');
-const { brownfieldE2eTestIds: ids } = require('@callstack/brownfield-example-shared-tests/e2e/e2eTestIds');
+const {
+  brownfieldE2ETestIds: ids,
+} = require('@callstack/brownfield-example-shared-tests/e2e/e2eTestIds');
 const {
   assertDetoxTextMatches,
   configureDetoxForBrownfieldIos,

--- a/apps/brownfield-example-shared-tests/e2e/appleAppExpoBrownfield.e2e.js
+++ b/apps/brownfield-example-shared-tests/e2e/appleAppExpoBrownfield.e2e.js
@@ -1,14 +1,12 @@
-const { device, element, by, expect: detoxExpect } = require('detox');
+const { element, by, expect: detoxExpect } = require('detox');
 const {
   brownfieldE2ETestIds: ids,
 } = require('@callstack/brownfield-example-shared-tests/e2e/e2eTestIds');
 const {
   assertDetoxTextMatches,
-  configureDetoxForBrownfieldIos,
-  waitForVisibleIgnoringSync,
+  launchBrownfieldAppForDetox,
 } = require('@callstack/brownfield-example-shared-tests/e2e/detoxUtils');
 const {
-  detoxLaunchArgs,
   scrollToNativeShellExpo,
   waitForAppleAppReadyExpo,
   openPostMessageTabExpo,
@@ -16,12 +14,8 @@ const {
 } = require('@callstack/brownfield-example-shared-tests/e2e/appleAppDetoxUtils');
 
 describe('Brownfield (AppleApp — Expo)', () => {
-  beforeEach(async () => {
-    await device.launchApp({
-      newInstance: true,
-      launchArgs: detoxLaunchArgs,
-    });
-    await configureDetoxForBrownfieldIos();
+  beforeAll(async () => {
+    await launchBrownfieldAppForDetox({ newInstance: true });
     await waitForAppleAppReadyExpo();
   });
 

--- a/apps/brownfield-example-shared-tests/e2e/createDetoxJestConfig.cjs
+++ b/apps/brownfield-example-shared-tests/e2e/createDetoxJestConfig.cjs
@@ -1,6 +1,7 @@
 'use strict';
 
 const path = require('node:path');
+const { DETOX_TIMING } = require('./detoxTiming.cjs');
 
 /**
  * Shared Detox Jest config for brownfield example apps (RNApp, ExpoApp54, ExpoApp55, AppleApp).
@@ -20,8 +21,7 @@ function createDetoxJestConfig({ e2eDir, testMatch }) {
     roots: [appRoot, sharedTestsRoot],
     // Shared E2E files live under brownfield-example-shared-tests; resolve host-app deps (detox) from here.
     modulePaths: [path.join(appRoot, 'node_modules')],
-    // beforeEach relaunches the app and waits for the embedded RN surface (up to ~80s on slow CI).
-    testTimeout: 300000,
+    testTimeout: DETOX_TIMING.TEST_TIMEOUT_MS,
     verbose: true,
     reporters: ['detox/runners/jest/reporter'],
     globalSetup: 'detox/runners/jest/globalSetup',

--- a/apps/brownfield-example-shared-tests/e2e/detoxTiming.cjs
+++ b/apps/brownfield-example-shared-tests/e2e/detoxTiming.cjs
@@ -1,0 +1,21 @@
+'use strict';
+
+/** Shared Detox timing constants — keep poll intervals and budgets centralized. */
+const DETOX_TIMING = {
+  /** Poll interval for the visibility of RN surfaces. */
+  POLL_INTERVAL_MS: 250,
+
+  /** Timeout for the visibility of RN surfaces. */
+  VISIBILITY_TIMEOUT_MS: 30_000,
+
+  /** Timeout for the visibility of post message bubbles. */
+  POST_MESSAGE_BUBBLE_TIMEOUT_MS: 15_000,
+
+  /** Timeout for the visibility of toasts. */
+  TOAST_VISIBILITY_TIMEOUT_MS: 15_000,
+
+  /** Timeout for the entire E2E test suite (detox + Jest + Maestro). */
+  TEST_TIMEOUT_MS: 300_000,
+};
+
+module.exports = { DETOX_TIMING };

--- a/apps/brownfield-example-shared-tests/e2e/detoxUtils.cjs
+++ b/apps/brownfield-example-shared-tests/e2e/detoxUtils.cjs
@@ -2,6 +2,11 @@ const assert = require('node:assert/strict');
 const { device, element, waitFor, expect: detoxExpect } = require('detox');
 const { DETOX_TIMING } = require('./detoxTiming.cjs');
 
+const detoxLaunchArgs = {
+  BrownfieldPreferEmbeddedBundleInDebug: 'YES',
+  DetoxE2E: 'YES',
+};
+
 function detoxAttrsText(attrs) {
   if (!attrs || typeof attrs !== 'object') {
     return '';
@@ -74,6 +79,7 @@ async function waitForVisibleIgnoringSync(matcher, timeoutMs = 20000, index = 0)
 }
 
 module.exports = {
+  detoxLaunchArgs,
   detoxAttrsText,
   assertDetoxTextMatches,
   configureDetoxForBrownfieldIos,

--- a/apps/brownfield-example-shared-tests/e2e/detoxUtils.cjs
+++ b/apps/brownfield-example-shared-tests/e2e/detoxUtils.cjs
@@ -36,6 +36,23 @@ async function configureDetoxForBrownfieldIos() {
 }
 
 /**
+ * Launch with synchronization disabled so Detox does not wait for RN Debug to become
+ * idle (Metro polling / animations can block until the Jest timeout).
+ */
+async function launchBrownfieldAppForDetox({ newInstance = true } = {}) {
+  await device.disableSynchronization();
+  try {
+    await device.launchApp({
+      newInstance,
+      launchArgs: detoxLaunchArgs,
+    });
+    await configureDetoxForBrownfieldIos();
+  } finally {
+    await device.enableSynchronization();
+  }
+}
+
+/**
  * Reload RN without waiting for the app to become idle. RN debug surfaces (and
  * animations) keep the run loop busy, so reload with sync enabled can hang until
  * the Jest timeout.
@@ -83,6 +100,7 @@ module.exports = {
   detoxAttrsText,
   assertDetoxTextMatches,
   configureDetoxForBrownfieldIos,
+  launchBrownfieldAppForDetox,
   reloadReactNativeIgnoringSync,
   waitForVisible,
   waitForVisibleIgnoringSync,

--- a/apps/brownfield-example-shared-tests/e2e/detoxUtils.cjs
+++ b/apps/brownfield-example-shared-tests/e2e/detoxUtils.cjs
@@ -1,5 +1,6 @@
 const assert = require('node:assert/strict');
 const { device, element, waitFor, expect: detoxExpect } = require('detox');
+const { DETOX_TIMING } = require('./detoxTiming.cjs');
 
 function detoxAttrsText(attrs) {
   if (!attrs || typeof attrs !== 'object') {
@@ -29,6 +30,20 @@ async function configureDetoxForBrownfieldIos() {
   ]);
 }
 
+/**
+ * Reload RN without waiting for the app to become idle. RN debug surfaces (and
+ * animations) keep the run loop busy, so reload with sync enabled can hang until
+ * the Jest timeout.
+ */
+async function reloadReactNativeIgnoringSync() {
+  await device.disableSynchronization();
+  try {
+    await device.reloadReactNative();
+  } finally {
+    await device.enableSynchronization();
+  }
+}
+
 async function waitForVisible(matcher, timeoutMs = 20000) {
   await waitFor(element(matcher)).toBeVisible().withTimeout(timeoutMs);
 }
@@ -47,7 +62,9 @@ async function waitForVisibleIgnoringSync(matcher, timeoutMs = 20000, index = 0)
         await detoxExpect(target()).toBeVisible();
         return;
       } catch {
-        await new Promise((resolve) => setTimeout(resolve, 200));
+        await new Promise((resolve) =>
+          setTimeout(resolve, DETOX_TIMING.POLL_INTERVAL_MS)
+        );
       }
     }
     await detoxExpect(target()).toBeVisible();
@@ -60,6 +77,7 @@ module.exports = {
   detoxAttrsText,
   assertDetoxTextMatches,
   configureDetoxForBrownfieldIos,
+  reloadReactNativeIgnoringSync,
   waitForVisible,
   waitForVisibleIgnoringSync,
 };

--- a/apps/brownfield-example-shared-tests/e2e/detoxUtils.cjs
+++ b/apps/brownfield-example-shared-tests/e2e/detoxUtils.cjs
@@ -36,45 +36,34 @@ async function configureDetoxForBrownfieldIos() {
 }
 
 /**
- * Launch with synchronization disabled so Detox does not wait for RN Debug to become
- * idle (Metro polling / animations can block until the Jest timeout).
+ * Launch without waiting for RN Debug idle, then re-enable Detox synchronization for tests.
+ *
+ * Sync is disabled only via launchArgs — disableSynchronization() before launchApp()
+ * fails because Detox is not connected to the app yet.
  */
 async function launchBrownfieldAppForDetox({ newInstance = true } = {}) {
-  await device.disableSynchronization();
-  try {
-    await device.launchApp({
-      newInstance,
-      launchArgs: detoxLaunchArgs,
-    });
-    await configureDetoxForBrownfieldIos();
-  } finally {
-    await device.enableSynchronization();
-  }
+  await device.launchApp({
+    newInstance,
+    launchArgs: {
+      ...detoxLaunchArgs,
+      detoxEnableSynchronization: 0,
+    },
+  });
+  await configureDetoxForBrownfieldIos();
+  await device.enableSynchronization();
+}
+
+async function waitForVisible(matcher, timeoutMs = 20000, index = 0) {
+  await waitFor(element(matcher).atIndex(index))
+    .toBeVisible()
+    .withTimeout(timeoutMs);
 }
 
 /**
- * Reload RN without waiting for the app to become idle. RN debug surfaces (and
- * animations) keep the run loop busy, so reload with sync enabled can hang until
- * the Jest timeout.
+ * Poll native-only / short-lived UI (toasts, popups, pushed native screens) with sync
+ * temporarily off. RN Debug can keep sync busy while a native overlay is already visible.
  */
-async function reloadReactNativeIgnoringSync() {
-  await device.disableSynchronization();
-  try {
-    await device.reloadReactNative();
-  } finally {
-    await device.enableSynchronization();
-  }
-}
-
-async function waitForVisible(matcher, timeoutMs = 20000) {
-  await waitFor(element(matcher)).toBeVisible().withTimeout(timeoutMs);
-}
-
-/**
- * Poll visibility with synchronization disabled (RN Debug keeps the run loop "busy").
- * Do not use waitFor().toBeVisible() while sync is off — it returns immediately.
- */
-async function waitForVisibleIgnoringSync(matcher, timeoutMs = 20000, index = 0) {
+async function waitForNativeOverlayVisible(matcher, timeoutMs = 20000, index = 0) {
   await device.disableSynchronization();
   try {
     const deadline = Date.now() + timeoutMs;
@@ -101,7 +90,6 @@ module.exports = {
   assertDetoxTextMatches,
   configureDetoxForBrownfieldIos,
   launchBrownfieldAppForDetox,
-  reloadReactNativeIgnoringSync,
   waitForVisible,
-  waitForVisibleIgnoringSync,
+  waitForNativeOverlayVisible,
 };

--- a/apps/brownfield-example-shared-tests/e2e/e2eTestIds.cjs
+++ b/apps/brownfield-example-shared-tests/e2e/e2eTestIds.cjs
@@ -1,7 +1,7 @@
 'use strict';
 
 // Detox E2E (CJS). Keep in sync with ../src/e2eTestIds.ts
-const brownfieldE2eTestIds = {
+const brownfieldE2ETestIds = {
   rnAppHome: 'brownfield-e2e-rnapp-home',
   rnAppHomeTitle: 'brownfield-e2e-rnapp-home-title',
   sendMessageToNative: 'brownfield-e2e-send-message-native',
@@ -18,5 +18,5 @@ const brownfieldE2eTestIds = {
 };
 
 module.exports = {
-  brownfieldE2eTestIds,
+  brownfieldE2ETestIds,
 };

--- a/apps/brownfield-example-shared-tests/e2e/expoPostMessageBrownfield.e2e.js
+++ b/apps/brownfield-example-shared-tests/e2e/expoPostMessageBrownfield.e2e.js
@@ -1,28 +1,22 @@
-const { device, element, by, waitFor, expect: detoxExpect } = require('detox');
+const { element, by, expect: detoxExpect } = require('detox');
 const {
   brownfieldE2ETestIds: ids,
 } = require('@callstack/brownfield-example-shared-tests/e2e/e2eTestIds');
 const {
   assertDetoxTextMatches,
-  configureDetoxForBrownfieldIos,
-  detoxLaunchArgs,
+  launchBrownfieldAppForDetox,
+  reloadReactNativeIgnoringSync,
+  waitForVisibleIgnoringSync,
 } = require('@callstack/brownfield-example-shared-tests/e2e/detoxUtils');
 
 describe('Brownfield postMessage (Expo demo)', () => {
   beforeEach(async () => {
-    // Full relaunch is more reliable than reloadReactNative() on newer RN/Xcode.
-    await device.launchApp({
-      newInstance: true,
-      launchArgs: detoxLaunchArgs,
-    });
-    await configureDetoxForBrownfieldIos();
-    const sendMessageButton = element(by.id(ids.sendMessageToNative));
+    await launchBrownfieldAppForDetox({ newInstance: true });
     try {
-      await waitFor(sendMessageButton).toBeVisible().withTimeout(45000);
+      await waitForVisibleIgnoringSync(by.id(ids.sendMessageToNative), 45000);
     } catch {
-      // Some CI runs start with an unmounted RN surface; one reload usually recovers.
-      await device.reloadReactNative();
-      await waitFor(sendMessageButton).toBeVisible().withTimeout(45000);
+      await reloadReactNativeIgnoringSync();
+      await waitForVisibleIgnoringSync(by.id(ids.sendMessageToNative), 45000);
     }
   });
 

--- a/apps/brownfield-example-shared-tests/e2e/expoPostMessageBrownfield.e2e.js
+++ b/apps/brownfield-example-shared-tests/e2e/expoPostMessageBrownfield.e2e.js
@@ -1,22 +1,21 @@
-const { element, by, expect: detoxExpect } = require('detox');
+const { device, element, by, expect: detoxExpect } = require('detox');
 const {
   brownfieldE2ETestIds: ids,
 } = require('@callstack/brownfield-example-shared-tests/e2e/e2eTestIds');
 const {
   assertDetoxTextMatches,
   launchBrownfieldAppForDetox,
-  reloadReactNativeIgnoringSync,
-  waitForVisibleIgnoringSync,
+  waitForVisible,
 } = require('@callstack/brownfield-example-shared-tests/e2e/detoxUtils');
 
 describe('Brownfield postMessage (Expo demo)', () => {
   beforeEach(async () => {
     await launchBrownfieldAppForDetox({ newInstance: true });
     try {
-      await waitForVisibleIgnoringSync(by.id(ids.sendMessageToNative), 45000);
+      await waitForVisible(by.id(ids.sendMessageToNative), 45000);
     } catch {
-      await reloadReactNativeIgnoringSync();
-      await waitForVisibleIgnoringSync(by.id(ids.sendMessageToNative), 45000);
+      await device.reloadReactNative();
+      await waitForVisible(by.id(ids.sendMessageToNative), 45000);
     }
   });
 

--- a/apps/brownfield-example-shared-tests/e2e/expoPostMessageBrownfield.e2e.js
+++ b/apps/brownfield-example-shared-tests/e2e/expoPostMessageBrownfield.e2e.js
@@ -1,8 +1,11 @@
 const { device, element, by, waitFor, expect: detoxExpect } = require('detox');
-const { brownfieldE2eTestIds: ids } = require('@callstack/brownfield-example-shared-tests/e2e/e2eTestIds');
+const {
+  brownfieldE2ETestIds: ids,
+} = require('@callstack/brownfield-example-shared-tests/e2e/e2eTestIds');
 const {
   assertDetoxTextMatches,
   configureDetoxForBrownfieldIos,
+  detoxLaunchArgs,
 } = require('@callstack/brownfield-example-shared-tests/e2e/detoxUtils');
 
 describe('Brownfield postMessage (Expo demo)', () => {
@@ -10,7 +13,7 @@ describe('Brownfield postMessage (Expo demo)', () => {
     // Full relaunch is more reliable than reloadReactNative() on newer RN/Xcode.
     await device.launchApp({
       newInstance: true,
-      launchArgs: { BrownfieldPreferEmbeddedBundleInDebug: 'YES' },
+      launchArgs: detoxLaunchArgs,
     });
     await configureDetoxForBrownfieldIos();
     const sendMessageButton = element(by.id(ids.sendMessageToNative));

--- a/apps/brownfield-example-shared-tests/e2e/rnAppBrownfield.e2e.js
+++ b/apps/brownfield-example-shared-tests/e2e/rnAppBrownfield.e2e.js
@@ -1,22 +1,21 @@
-const { element, by, expect: detoxExpect } = require('detox');
+const { device, element, by, expect: detoxExpect } = require('detox');
 const {
   brownfieldE2ETestIds: ids,
 } = require('@callstack/brownfield-example-shared-tests/e2e/e2eTestIds');
 const {
   assertDetoxTextMatches,
   launchBrownfieldAppForDetox,
-  reloadReactNativeIgnoringSync,
-  waitForVisibleIgnoringSync,
+  waitForVisible,
 } = require('@callstack/brownfield-example-shared-tests/e2e/detoxUtils');
 
 describe('Brownfield (RNApp)', () => {
   beforeAll(async () => {
     await launchBrownfieldAppForDetox({ newInstance: true });
     try {
-      await waitForVisibleIgnoringSync(by.id(ids.rnAppHome), 45000);
+      await waitForVisible(by.id(ids.rnAppHome), 45000);
     } catch {
-      await reloadReactNativeIgnoringSync();
-      await waitForVisibleIgnoringSync(by.id(ids.rnAppHome), 45000);
+      await device.reloadReactNative();
+      await waitForVisible(by.id(ids.rnAppHome), 45000);
     }
   });
 

--- a/apps/brownfield-example-shared-tests/e2e/rnAppBrownfield.e2e.js
+++ b/apps/brownfield-example-shared-tests/e2e/rnAppBrownfield.e2e.js
@@ -1,28 +1,22 @@
-const { device, element, by, waitFor, expect: detoxExpect } = require('detox');
+const { element, by, expect: detoxExpect } = require('detox');
 const {
   brownfieldE2ETestIds: ids,
 } = require('@callstack/brownfield-example-shared-tests/e2e/e2eTestIds');
 const {
   assertDetoxTextMatches,
-  configureDetoxForBrownfieldIos,
-  detoxLaunchArgs,
+  launchBrownfieldAppForDetox,
+  reloadReactNativeIgnoringSync,
+  waitForVisibleIgnoringSync,
 } = require('@callstack/brownfield-example-shared-tests/e2e/detoxUtils');
 
 describe('Brownfield (RNApp)', () => {
-  beforeEach(async () => {
-    // Full relaunch is more reliable than reloadReactNative() on newer RN/Xcode.
-    await device.launchApp({
-      newInstance: true,
-      launchArgs: detoxLaunchArgs,
-    });
-    await configureDetoxForBrownfieldIos();
-    const home = element(by.id(ids.rnAppHome));
+  beforeAll(async () => {
+    await launchBrownfieldAppForDetox({ newInstance: true });
     try {
-      await waitFor(home).toBeVisible().withTimeout(45000);
+      await waitForVisibleIgnoringSync(by.id(ids.rnAppHome), 45000);
     } catch {
-      // Some CI runs start with an unmounted RN surface; one reload usually recovers.
-      await device.reloadReactNative();
-      await waitFor(home).toBeVisible().withTimeout(45000);
+      await reloadReactNativeIgnoringSync();
+      await waitForVisibleIgnoringSync(by.id(ids.rnAppHome), 45000);
     }
   });
 

--- a/apps/brownfield-example-shared-tests/e2e/rnAppBrownfield.e2e.js
+++ b/apps/brownfield-example-shared-tests/e2e/rnAppBrownfield.e2e.js
@@ -1,8 +1,11 @@
 const { device, element, by, waitFor, expect: detoxExpect } = require('detox');
-const { brownfieldE2eTestIds: ids } = require('@callstack/brownfield-example-shared-tests/e2e/e2eTestIds');
+const {
+  brownfieldE2ETestIds: ids,
+} = require('@callstack/brownfield-example-shared-tests/e2e/e2eTestIds');
 const {
   assertDetoxTextMatches,
   configureDetoxForBrownfieldIos,
+  detoxLaunchArgs,
 } = require('@callstack/brownfield-example-shared-tests/e2e/detoxUtils');
 
 describe('Brownfield (RNApp)', () => {
@@ -10,7 +13,7 @@ describe('Brownfield (RNApp)', () => {
     // Full relaunch is more reliable than reloadReactNative() on newer RN/Xcode.
     await device.launchApp({
       newInstance: true,
-      launchArgs: { BrownfieldPreferEmbeddedBundleInDebug: 'YES' },
+      launchArgs: detoxLaunchArgs,
     });
     await configureDetoxForBrownfieldIos();
     const home = element(by.id(ids.rnAppHome));

--- a/apps/brownfield-example-shared-tests/jest/expo-config.js
+++ b/apps/brownfield-example-shared-tests/jest/expo-config.js
@@ -11,6 +11,7 @@ function createExpoJestConfig({ appRootDir, moduleNameMapper = {} }) {
       '^react$': appRequire.resolve('react'),
       '^react/jsx-runtime$': appRequire.resolve('react/jsx-runtime'),
       '^react/jsx-dev-runtime$': appRequire.resolve('react/jsx-dev-runtime'),
+      '^react-native$': appRequire.resolve('react-native'),
       '^@testing-library/react-native$': appRequire.resolve(
         '@testing-library/react-native'
       ),

--- a/apps/brownfield-example-shared-tests/package.json
+++ b/apps/brownfield-example-shared-tests/package.json
@@ -9,6 +9,7 @@
   "types": "src/index.ts",
   "exports": {
     ".": "./src/index.ts",
+    "./runtime": "./src/runtime.ts",
     "./jest/setup": "./jest/setup.js",
     "./e2eTestIds": "./src/e2eTestIds.ts",
     "./e2e/e2eTestIds": "./e2e/e2eTestIds.cjs",

--- a/apps/brownfield-example-shared-tests/src/e2eTestIds.ts
+++ b/apps/brownfield-example-shared-tests/src/e2eTestIds.ts
@@ -1,7 +1,7 @@
 /**
  * Stable identifiers for Detox (and optional Maestro) runs across demo apps.
  */
-export const brownfieldE2eTestIds = {
+export const brownfieldE2ETestIds = {
   rnAppHome: 'brownfield-e2e-rnapp-home',
   /** Title copy on RNApp home — use for Detox instead of `by.text` (iOS accessibility / Fabric). */
   rnAppHomeTitle: 'brownfield-e2e-rnapp-home-title',

--- a/apps/brownfield-example-shared-tests/src/index.ts
+++ b/apps/brownfield-example-shared-tests/src/index.ts
@@ -1,4 +1,12 @@
+export {
+  isBrownfieldE2EMode,
+  setBrownfieldE2EMode,
+  syncBrownfieldE2EModeFromRootProps,
+  userAlert,
+  type BrownfieldRootProps,
+} from './userAlert';
 export { runPostMessageTabSuite } from './suites/postMessageTab.suite';
 export { runCounterSuite } from './suites/counter.suite';
 export { runExpoRnAppSuite } from './suites/expoRnApp.suite';
 export { runHomeScreenSuite } from './suites/homeScreen.suite';
+export { runUserAlertSuite } from './suites/userAlert.suite';

--- a/apps/brownfield-example-shared-tests/src/index.ts
+++ b/apps/brownfield-example-shared-tests/src/index.ts
@@ -1,12 +1,12 @@
+export { runPostMessageTabSuite } from './suites/postMessageTab.suite';
+export { runCounterSuite } from './suites/counter.suite';
+export { runExpoRnAppSuite } from './suites/expoRnApp.suite';
+export { runHomeScreenSuite } from './suites/homeScreen.suite';
+export { runUserAlertSuite } from './suites/userAlert.suite';
 export {
   isBrownfieldE2EMode,
   setBrownfieldE2EMode,
   syncBrownfieldE2EModeFromRootProps,
   userAlert,
   type BrownfieldRootProps,
-} from './userAlert';
-export { runPostMessageTabSuite } from './suites/postMessageTab.suite';
-export { runCounterSuite } from './suites/counter.suite';
-export { runExpoRnAppSuite } from './suites/expoRnApp.suite';
-export { runHomeScreenSuite } from './suites/homeScreen.suite';
-export { runUserAlertSuite } from './suites/userAlert.suite';
+} from './runtime';

--- a/apps/brownfield-example-shared-tests/src/runtime.ts
+++ b/apps/brownfield-example-shared-tests/src/runtime.ts
@@ -1,0 +1,7 @@
+export {
+  isBrownfieldE2EMode,
+  setBrownfieldE2EMode,
+  syncBrownfieldE2EModeFromRootProps,
+  userAlert,
+  type BrownfieldRootProps,
+} from './userAlert';

--- a/apps/brownfield-example-shared-tests/src/suites/expoRnApp.suite.tsx
+++ b/apps/brownfield-example-shared-tests/src/suites/expoRnApp.suite.tsx
@@ -1,8 +1,9 @@
+import type { BrownfieldRootProps } from '../userAlert';
 import type { ComponentType } from 'react';
 import { render, fireEvent, screen } from '@testing-library/react-native';
 import BrownfieldNavigation from '@callstack/brownfield-navigation';
 
-type RNAppProps = { nativeOsVersionLabel?: string };
+type RNAppProps = BrownfieldRootProps;
 
 function resetBrownieExampleStore() {
   const g = globalThis as typeof globalThis & {

--- a/apps/brownfield-example-shared-tests/src/suites/userAlert.suite.ts
+++ b/apps/brownfield-example-shared-tests/src/suites/userAlert.suite.ts
@@ -1,0 +1,35 @@
+import { Alert } from 'react-native';
+import { setBrownfieldE2EMode, userAlert } from '../userAlert';
+
+export function runUserAlertSuite(appLabel: string) {
+  describe(`userAlert - ${appLabel}`, () => {
+    const alertSpy = jest.spyOn(Alert, 'alert');
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    afterEach(() => {
+      setBrownfieldE2EMode(false);
+      alertSpy.mockClear();
+      logSpy.mockClear();
+    });
+
+    afterAll(() => {
+      alertSpy.mockRestore();
+      logSpy.mockRestore();
+    });
+
+    it('shows a native alert outside E2E mode', () => {
+      userAlert('No update available');
+      expect(alertSpy).toHaveBeenCalledWith('No update available');
+      expect(logSpy).not.toHaveBeenCalled();
+    });
+
+    it('logs to console in E2E mode', () => {
+      setBrownfieldE2EMode(true);
+      userAlert('Update check failed', 'network error');
+      expect(alertSpy).not.toHaveBeenCalled();
+      expect(logSpy).toHaveBeenCalledWith(
+        '[userAlert] Update check failed: network error'
+      );
+    });
+  });
+}

--- a/apps/brownfield-example-shared-tests/src/userAlert.ts
+++ b/apps/brownfield-example-shared-tests/src/userAlert.ts
@@ -1,0 +1,35 @@
+import { Alert } from 'react-native';
+
+let brownfieldE2EMode = false;
+
+export function setBrownfieldE2EMode(enabled: boolean) {
+  brownfieldE2EMode = enabled;
+}
+
+export function isBrownfieldE2EMode() {
+  return brownfieldE2EMode;
+}
+
+export type BrownfieldRootProps = {
+  nativeOsVersionLabel?: string;
+  brownfieldE2E?: boolean;
+};
+
+export function syncBrownfieldE2EModeFromRootProps(brownfieldE2E?: boolean) {
+  setBrownfieldE2EMode(brownfieldE2E ?? false);
+}
+
+export function userAlert(title: string, message?: string) {
+  if (brownfieldE2EMode) {
+    console.log(
+      `[userAlert] ${title}${message !== undefined ? `: ${message}` : ''}`
+    );
+    return;
+  }
+
+  if (message !== undefined) {
+    Alert.alert(title, message);
+  } else {
+    Alert.alert(title);
+  }
+}

--- a/packages/react-native-brownfield/src/expo-config-plugin/ios/podfileHelpers.ts
+++ b/packages/react-native-brownfield/src/expo-config-plugin/ios/podfileHelpers.ts
@@ -10,10 +10,6 @@ const BROWNFIELD_EXPO_GTE_55_SWIFT_DEFINES_MARKER_START =
   '# >>> react-native-brownfield Expo SDK 55+ swift defines >>>';
 const BROWNFIELD_EXPO_GTE_55_SWIFT_DEFINES_MARKER_END =
   '# <<< react-native-brownfield Expo SDK 55+ swift defines <<<';
-const BROWNFIELD_DEBUG_E2E_POD_SETTINGS_MARKER_START =
-  '# >>> react-native-brownfield Debug E2E pod settings >>>';
-const BROWNFIELD_DEBUG_E2E_POD_SETTINGS_MARKER_END =
-  '# <<< react-native-brownfield Debug E2E pod settings <<<';
 const BROWNFIELD_POST_INTEGRATE_REQUIRE = `require File.join(File.dirname(\`node --print "require.resolve('@callstack/react-native-brownfield/package.json')"\`), "scripts/react_native_brownfield_post_integrate")`;
 const REACT_NATIVE_PODS_REQUIRE_REGEX =
   /^require File\.join\(File\.dirname\(`node --print "require\.resolve\('react-native\/package\.json'\)"`\), "scripts\/react_native_pods"\)\s*$/m;
@@ -58,24 +54,10 @@ ${BROWNFIELD_POD_HOOK_MARKER_END}
 }
 
 function ensureExpoDefinesForSDK55AndAbove(podfile: string): string {
-  let modifiedPodfile = podfile;
-
-  if (
-    !modifiedPodfile.includes(BROWNFIELD_EXPO_GTE_55_SWIFT_DEFINES_MARKER_START)
-  ) {
-    modifiedPodfile = injectExpoGte55SwiftDefinesHook(modifiedPodfile);
+  if (podfile.includes(BROWNFIELD_EXPO_GTE_55_SWIFT_DEFINES_MARKER_START)) {
+    return podfile;
   }
 
-  if (
-    !modifiedPodfile.includes(BROWNFIELD_DEBUG_E2E_POD_SETTINGS_MARKER_START)
-  ) {
-    modifiedPodfile = injectBrownfieldDebugE2ePodSettingsHook(modifiedPodfile);
-  }
-
-  return modifiedPodfile;
-}
-
-function injectExpoGte55SwiftDefinesHook(podfile: string): string {
   const hook = `
     ${BROWNFIELD_EXPO_GTE_55_SWIFT_DEFINES_MARKER_START}
     installer.pods_project.targets.each do |target|
@@ -92,30 +74,6 @@ function injectExpoGte55SwiftDefinesHook(podfile: string): string {
     ${BROWNFIELD_EXPO_GTE_55_SWIFT_DEFINES_MARKER_END}
 `;
 
-  return injectIntoPostInstall(podfile, hook);
-}
-
-function injectBrownfieldDebugE2ePodSettingsHook(podfile: string): string {
-  const hook = `
-    ${BROWNFIELD_DEBUG_E2E_POD_SETTINGS_MARKER_START}
-    brownfield_debug_pods = %w[Brownie BrownfieldNavigation ReactBrownfield]
-    installer.pods_project.targets.each do |target|
-      next unless brownfield_debug_pods.include?(target.name)
-
-      target.build_configurations.each do |config|
-        next unless config.name == 'Debug'
-
-        config.build_settings['BUILD_LIBRARY_FOR_DISTRIBUTION'] = 'NO'
-        config.build_settings['SWIFT_EMIT_MODULE_INTERFACE'] = 'NO'
-      end
-    end
-    ${BROWNFIELD_DEBUG_E2E_POD_SETTINGS_MARKER_END}
-`;
-
-  return injectIntoPostInstall(podfile, hook);
-}
-
-function injectIntoPostInstall(podfile: string, hook: string): string {
   const postInstallMatch = podfile.match(
     /(post_install\s+do\s+\|installer\|\s*\n)((?:(?!^\s*end\s*$)[\s\S])*)(^\s*end\s*$)/m
   );

--- a/packages/react-native-brownfield/src/expo-config-plugin/ios/podfileHelpers.ts
+++ b/packages/react-native-brownfield/src/expo-config-plugin/ios/podfileHelpers.ts
@@ -10,6 +10,10 @@ const BROWNFIELD_EXPO_GTE_55_SWIFT_DEFINES_MARKER_START =
   '# >>> react-native-brownfield Expo SDK 55+ swift defines >>>';
 const BROWNFIELD_EXPO_GTE_55_SWIFT_DEFINES_MARKER_END =
   '# <<< react-native-brownfield Expo SDK 55+ swift defines <<<';
+const BROWNFIELD_DEBUG_E2E_POD_SETTINGS_MARKER_START =
+  '# >>> react-native-brownfield Debug E2E pod settings >>>';
+const BROWNFIELD_DEBUG_E2E_POD_SETTINGS_MARKER_END =
+  '# <<< react-native-brownfield Debug E2E pod settings <<<';
 const BROWNFIELD_POST_INTEGRATE_REQUIRE = `require File.join(File.dirname(\`node --print "require.resolve('@callstack/react-native-brownfield/package.json')"\`), "scripts/react_native_brownfield_post_integrate")`;
 const REACT_NATIVE_PODS_REQUIRE_REGEX =
   /^require File\.join\(File\.dirname\(`node --print "require\.resolve\('react-native\/package\.json'\)"`\), "scripts\/react_native_pods"\)\s*$/m;
@@ -54,10 +58,24 @@ ${BROWNFIELD_POD_HOOK_MARKER_END}
 }
 
 function ensureExpoDefinesForSDK55AndAbove(podfile: string): string {
-  if (podfile.includes(BROWNFIELD_EXPO_GTE_55_SWIFT_DEFINES_MARKER_START)) {
-    return podfile;
+  let modifiedPodfile = podfile;
+
+  if (
+    !modifiedPodfile.includes(BROWNFIELD_EXPO_GTE_55_SWIFT_DEFINES_MARKER_START)
+  ) {
+    modifiedPodfile = injectExpoGte55SwiftDefinesHook(modifiedPodfile);
   }
 
+  if (
+    !modifiedPodfile.includes(BROWNFIELD_DEBUG_E2E_POD_SETTINGS_MARKER_START)
+  ) {
+    modifiedPodfile = injectBrownfieldDebugE2ePodSettingsHook(modifiedPodfile);
+  }
+
+  return modifiedPodfile;
+}
+
+function injectExpoGte55SwiftDefinesHook(podfile: string): string {
   const hook = `
     ${BROWNFIELD_EXPO_GTE_55_SWIFT_DEFINES_MARKER_START}
     installer.pods_project.targets.each do |target|
@@ -74,6 +92,30 @@ function ensureExpoDefinesForSDK55AndAbove(podfile: string): string {
     ${BROWNFIELD_EXPO_GTE_55_SWIFT_DEFINES_MARKER_END}
 `;
 
+  return injectIntoPostInstall(podfile, hook);
+}
+
+function injectBrownfieldDebugE2ePodSettingsHook(podfile: string): string {
+  const hook = `
+    ${BROWNFIELD_DEBUG_E2E_POD_SETTINGS_MARKER_START}
+    brownfield_debug_pods = %w[Brownie BrownfieldNavigation ReactBrownfield]
+    installer.pods_project.targets.each do |target|
+      next unless brownfield_debug_pods.include?(target.name)
+
+      target.build_configurations.each do |config|
+        next unless config.name == 'Debug'
+
+        config.build_settings['BUILD_LIBRARY_FOR_DISTRIBUTION'] = 'NO'
+        config.build_settings['SWIFT_EMIT_MODULE_INTERFACE'] = 'NO'
+      end
+    end
+    ${BROWNFIELD_DEBUG_E2E_POD_SETTINGS_MARKER_END}
+`;
+
+  return injectIntoPostInstall(podfile, hook);
+}
+
+function injectIntoPostInstall(podfile: string, hook: string): string {
   const postInstallMatch = podfile.match(
     /(post_install\s+do\s+\|installer\|\s*\n)((?:(?!^\s*end\s*$)[\s\S])*)(^\s*end\s*$)/m
   );

--- a/scripts/ci-local-appleapp-ios-e2e.sh
+++ b/scripts/ci-local-appleapp-ios-e2e.sh
@@ -10,7 +10,9 @@
 #   yarn ci:local:appleapp:e2e:ios --rebuild
 #   yarn ci:local:appleapp:e2e:ios --test-only
 #   yarn ci:local:appleapp:e2e:ios --build-only
+#   yarn ci:local:appleapp:e2e:ios --no-restore-pods   # keep E2E Pods.xcodeproj patches after exit
 #
+# Local runs auto-run `pod install` on exit to restore Brownfield pod Debug settings (vanilla RN host).
 # From apps/AppleApp: yarn ci:local:e2e:ios [--flags]
 #
 set -euo pipefail
@@ -80,6 +82,7 @@ if ci_local_e2e_should_build "${TEST_ONLY}" && [[ "${REBUILD_ONLY}" != "true" ]]
 
     echo "==> pod install (RNApp — build RN from source for RNScreens)"
     (cd "${RN_PROJECT_IOS_PATH}" && RCT_USE_PREBUILT_RNCORE=0 pod install)
+    ci_local_e2e_apply_brownfield_debug_pod_settings "${RN_PROJECT_IOS_PATH}"
   fi
 
   echo "==> Package ${XCFRAMEWORK_APP} XCFramework for AppleApp"

--- a/scripts/ci-local-expo55-ios-e2e.sh
+++ b/scripts/ci-local-expo55-ios-e2e.sh
@@ -50,6 +50,7 @@ if ci_local_e2e_should_build "${TEST_ONLY}" && [[ "${SKIP_INSTALL}" == "false" ]
 
   echo "==> pod install"
   (cd "${IOS_PATH}" && pod install)
+  ci_local_e2e_apply_brownfield_debug_pod_settings "${IOS_PATH}"
 
   ci_local_e2e_run_detox_postinstall "${APP_PATH}"
 elif [[ "${REBUILD_ONLY}" == "true" ]]; then
@@ -57,6 +58,7 @@ elif [[ "${REBUILD_ONLY}" == "true" ]]; then
 fi
 
 if ci_local_e2e_should_build "${TEST_ONLY}"; then
+  ci_local_e2e_apply_brownfield_debug_pod_settings "${IOS_PATH}"
   ci_local_e2e_ensure_ios_xcode_env_updates "${IOS_PATH}"
   ci_local_e2e_run_detox_build "${APP_PATH}"
   DETOX_APP="${IOS_PATH}/build/Build/Products/Debug-iphonesimulator/${APP_NAME}.app"

--- a/scripts/ci-local-expo55-ios-e2e.sh
+++ b/scripts/ci-local-expo55-ios-e2e.sh
@@ -8,7 +8,9 @@
 #   yarn ci:local:expo55:e2e:ios --rebuild           # Detox build + test (skip yarn install / prebuild / pods)
 #   yarn ci:local:expo55:e2e:ios --test-only         # tests only — does NOT rebuild the app
 #   yarn ci:local:expo55:e2e:ios --build-only        # build Detox app, skip tests
+#   yarn ci:local:expo55:e2e:ios --no-restore-pods   # keep E2E Pods.xcodeproj patches after exit
 #
+# Local runs auto-run `pod install` on exit to restore Brownfield pod Debug settings.
 # From apps/ExpoApp55: yarn ci:local:e2e:ios [--flags]
 #
 set -euo pipefail

--- a/scripts/ci-local-ios-e2e-common.sh
+++ b/scripts/ci-local-ios-e2e-common.sh
@@ -76,6 +76,7 @@ ci_local_e2e_install_applesimutils() {
     if ! command -v applesimutils >/dev/null 2>&1; then
       echo "==> Installing applesimutils (Detox iOS simulator helper)"
       brew tap wix/brew
+      brew trust --formula wix/brew/applesimutils 2>/dev/null || true
       brew install applesimutils
     else
       echo "==> applesimutils already installed: $(command -v applesimutils)"

--- a/scripts/ci-local-ios-e2e-common.sh
+++ b/scripts/ci-local-ios-e2e-common.sh
@@ -144,8 +144,28 @@ ci_local_e2e_restore_tracked_pod_settings() {
   done
 }
 
+ci_local_e2e_ensure_xcodeproj_gem() {
+  local app_root="$1"
+
+  if [[ -f "${app_root}/Gemfile" ]]; then
+    echo "==> bundle install (${app_root}) for xcodeproj"
+    (cd "${app_root}" && bundle install --quiet)
+    if (cd "${app_root}" && bundle exec ruby -e "require 'xcodeproj'" 2>/dev/null); then
+      return 0
+    fi
+  fi
+
+  if ruby -e "require 'xcodeproj'" 2>/dev/null; then
+    return 0
+  fi
+
+  echo "==> gem install xcodeproj"
+  gem install xcodeproj --no-document --version 1.25.1
+}
+
 ci_local_e2e_apply_brownfield_debug_pod_settings() {
   local ios_path="$1"
+  local app_root="$(cd "${ios_path}/.." && pwd)"
   local pods_project="${ios_path}/Pods/Pods.xcodeproj"
 
   if [[ ! -d "${pods_project}" ]]; then
@@ -153,8 +173,13 @@ ci_local_e2e_apply_brownfield_debug_pod_settings() {
     return 0
   fi
 
+  ci_local_e2e_ensure_xcodeproj_gem "${app_root}"
+
   echo "==> Brownfield pods: disable Swift module interface for Debug E2E builds"
-  ruby - "${pods_project}" <<'RUBY'
+
+  if [[ -f "${app_root}/Gemfile" ]] \
+    && (cd "${app_root}" && bundle exec ruby -e "require 'xcodeproj'" 2>/dev/null); then
+    (cd "${app_root}" && bundle exec ruby - "${pods_project}" <<'RUBY'
 require 'xcodeproj'
 
 project = Xcodeproj::Project.open(ARGV[0])
@@ -173,6 +198,28 @@ end
 
 project.save
 RUBY
+    )
+  else
+    ruby - "${pods_project}" <<'RUBY'
+require 'xcodeproj'
+
+project = Xcodeproj::Project.open(ARGV[0])
+brownfield_pods = %w[Brownie BrownfieldNavigation ReactBrownfield]
+
+project.targets.each do |target|
+  next unless brownfield_pods.include?(target.name)
+
+  target.build_configurations.each do |config|
+    next unless config.name == 'Debug'
+
+    config.build_settings['BUILD_LIBRARY_FOR_DISTRIBUTION'] = 'NO'
+    config.build_settings['SWIFT_EMIT_MODULE_INTERFACE'] = 'NO'
+  end
+end
+
+project.save
+RUBY
+  fi
 
   ci_local_e2e_register_pod_settings_restore "${ios_path}"
 }

--- a/scripts/ci-local-ios-e2e-common.sh
+++ b/scripts/ci-local-ios-e2e-common.sh
@@ -24,6 +24,7 @@ ci_local_e2e_parse_common_flags() {
   REBUILD_ONLY=false
   BUILD_ONLY=false
   CLEAN_IOS=false
+  NO_RESTORE_PODS=false
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -34,6 +35,10 @@ ci_local_e2e_parse_common_flags() {
       --rebuild) REBUILD_ONLY=true; SKIP_INSTALL=true; SKIP_BREW=true; shift ;;
       --build-only) BUILD_ONLY=true; shift ;;
       --clean-ios) CLEAN_IOS=true; shift ;;
+      --no-restore-pods)
+        NO_RESTORE_PODS=true
+        shift
+        ;;
       *)
         return 0
         ;;
@@ -90,6 +95,54 @@ ci_local_e2e_run_detox_postinstall() {
   (cd "${app_path}" && node node_modules/detox/scripts/postinstall.js)
 }
 
+CI_LOCAL_E2E_IOS_PATHS_FOR_POD_RESTORE=()
+CI_LOCAL_E2E_POD_RESTORE_TRAP_REGISTERED=0
+
+ci_local_e2e_register_pod_settings_restore() {
+  local ios_path="$1"
+  local existing
+
+  if [[ "${NO_RESTORE_PODS:-false}" == "true" ]] || [[ -n "${CI:-}" ]]; then
+    return 0
+  fi
+
+  for existing in "${CI_LOCAL_E2E_IOS_PATHS_FOR_POD_RESTORE[@]}"; do
+    if [[ "${existing}" == "${ios_path}" ]]; then
+      return 0
+    fi
+  done
+
+  CI_LOCAL_E2E_IOS_PATHS_FOR_POD_RESTORE+=("${ios_path}")
+
+  if [[ "${CI_LOCAL_E2E_POD_RESTORE_TRAP_REGISTERED}" != "1" ]]; then
+    trap ci_local_e2e_restore_tracked_pod_settings EXIT
+    CI_LOCAL_E2E_POD_RESTORE_TRAP_REGISTERED=1
+  fi
+}
+
+ci_local_e2e_restore_brownfield_debug_pod_settings() {
+  local ios_path="$1"
+
+  if [[ ! -f "${ios_path}/Podfile.lock" ]]; then
+    return 0
+  fi
+
+  echo "==> Restore iOS Pods after E2E (pod install — resets Brownfield Debug pod settings)"
+  (cd "${ios_path}" && pod install)
+}
+
+ci_local_e2e_restore_tracked_pod_settings() {
+  local ios_path
+
+  if [[ "${#CI_LOCAL_E2E_IOS_PATHS_FOR_POD_RESTORE[@]}" -eq 0 ]]; then
+    return 0
+  fi
+
+  for ios_path in "${CI_LOCAL_E2E_IOS_PATHS_FOR_POD_RESTORE[@]}"; do
+    ci_local_e2e_restore_brownfield_debug_pod_settings "${ios_path}"
+  done
+}
+
 ci_local_e2e_apply_brownfield_debug_pod_settings() {
   local ios_path="$1"
   local pods_project="${ios_path}/Pods/Pods.xcodeproj"
@@ -119,6 +172,8 @@ end
 
 project.save
 RUBY
+
+  ci_local_e2e_register_pod_settings_restore "${ios_path}"
 }
 
 ci_local_e2e_ensure_ios_xcode_env_updates() {

--- a/scripts/ci-local-ios-e2e-common.sh
+++ b/scripts/ci-local-ios-e2e-common.sh
@@ -86,7 +86,39 @@ ci_local_e2e_should_build() {
 ci_local_e2e_run_detox_postinstall() {
   local app_path="$1"
   echo "==> Detox iOS postinstall (single run, avoids monorepo race)"
-  node "${app_path}/node_modules/detox/scripts/postinstall.js"
+  # Detox postinstall patches android/ relative to cwd; run from the app root (same as CI AppleApp step).
+  (cd "${app_path}" && node node_modules/detox/scripts/postinstall.js)
+}
+
+ci_local_e2e_apply_brownfield_debug_pod_settings() {
+  local ios_path="$1"
+  local pods_project="${ios_path}/Pods/Pods.xcodeproj"
+
+  if [[ ! -d "${pods_project}" ]]; then
+    echo "warning: ${pods_project} not found; skipping Brownfield Debug pod settings" >&2
+    return 0
+  fi
+
+  echo "==> Brownfield pods: disable Swift module interface for Debug E2E builds"
+  ruby - "${pods_project}" <<'RUBY'
+require 'xcodeproj'
+
+project = Xcodeproj::Project.open(ARGV[0])
+brownfield_pods = %w[Brownie BrownfieldNavigation ReactBrownfield]
+
+project.targets.each do |target|
+  next unless brownfield_pods.include?(target.name)
+
+  target.build_configurations.each do |config|
+    next unless config.name == 'Debug'
+
+    config.build_settings['BUILD_LIBRARY_FOR_DISTRIBUTION'] = 'NO'
+    config.build_settings['SWIFT_EMIT_MODULE_INTERFACE'] = 'NO'
+  end
+end
+
+project.save
+RUBY
 }
 
 ci_local_e2e_ensure_ios_xcode_env_updates() {

--- a/scripts/ci-local-rnapp-ios-e2e.sh
+++ b/scripts/ci-local-rnapp-ios-e2e.sh
@@ -8,7 +8,9 @@
 #   yarn ci:local:rnapp:e2e:ios --rebuild           # Detox build + test (skip yarn install / pods)
 #   yarn ci:local:rnapp:e2e:ios --test-only         # tests only — does NOT rebuild the app
 #   yarn ci:local:rnapp:e2e:ios --build-only        # build Detox app, skip tests
+#   yarn ci:local:rnapp:e2e:ios --no-restore-pods   # keep E2E Pods.xcodeproj patches after exit
 #
+# Local runs auto-run `pod install` on exit to restore Brownfield pod Debug settings.
 # From apps/RNApp: yarn ci:local:e2e:ios [--flags]
 #
 set -euo pipefail
@@ -43,6 +45,7 @@ if ci_local_e2e_should_build "${TEST_ONLY}" && [[ "${SKIP_INSTALL}" == "false" ]
 
   echo "==> pod install (RCT_USE_PREBUILT_RNCORE=0 — build RN from source for RNScreens)"
   (cd "${IOS_PATH}" && RCT_USE_PREBUILT_RNCORE=0 pod install)
+  ci_local_e2e_apply_brownfield_debug_pod_settings "${IOS_PATH}"
 
   ci_local_e2e_run_detox_postinstall "${APP_PATH}"
 elif [[ "${REBUILD_ONLY}" == "true" ]]; then


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
This PR:
- stabilizes flaky E2E tests by scrolling the embedded RN surface into view and reloading with Detox sync disabled, so recovery doesn’t hang until the Jest timeout while waiting for an idle app that never settles due to RN debug animations
- adds ccache to speed up Android CXX build times
- builds only one variant (x86_64) of the Android app in CI to speed up the build
- pins SHA checksums of GH Actions
- upgrade outdated actions causing warnings
- disables cache in release workflows for security (both Android cache for BGP release workflow & Node cache for NPM publish workflow)
- do not show alert in e2e tests on both platforms to stabilize flaky E2E tests
  <img width="30%" src="https://github.com/user-attachments/assets/d072b253-6464-4927-93b1-c8c6398f46fe" />
- improves broken local E2E suite by:
  - running Detox postinstall from the app directory (matches CI’s AppleApp step)
  - adding `ci_local_e2e_apply_brownfield_debug_pod_settings` Podfile func to turn off Swift module interface emission for Debug on the three Brownfield pods
  - (follow-up issue fixes will follow) - on Expo locally without Metro, with Detox, crashes due to injected Metro-specific debug-only code appear, which may be a bigger issue with the (debug + expo + include prebuilt JS bundle) scenario - CC @adamTrz / @alpharius-ck
- disable Detox sync on Expo app startup to conserve time (otherwise, same E2E on vanilla take ~15 mins while on Expo: ~40 mins)

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
CI green (few consecutive re-runs of E2E succeed).
