### PR TITLE
fix: schema not released

### DIFF
--- a/.changeset/quick-parrots-shine.md
+++ b/.changeset/quick-parrots-shine.md
@@ -1,0 +1,5 @@
+---
+'@callstack/brownfield-cli': minor
+---
+
+Fix schema.json not being released

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -69,7 +69,8 @@
     "!**/__fixtures__",
     "!**/__mocks__",
     "!**/.*",
-    "README.md"
+    "README.md",
+    "schema.json"
   ],
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
### Summary

`schema.json` is not released causing errors in the brownfield cli.

