### PR TITLE
fix: brownfield Gradle Plugin not to depend on *UpdatesResources task from expo-updates if absent

### DIFF
--- a/.changeset/fair-swans-remain.md
+++ b/.changeset/fair-swans-remain.md
@@ -1,0 +1,5 @@
+---
+'@callstack/react-native-brownfield': patch
+---
+
+fix: brownfield Gradle Plugin not to depend on \*UpdatesResources task from expo-updates if it is absent

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,11 @@ jobs:
           CLANG_MODULE_CACHE_PATH="$RUNNER_TEMP/swift-cache/clang" \
           swift test --scratch-path "$RUNNER_TEMP/swift-cache/swiftpm"
 
+      - name: Run brownfield tests including MacOS-only tests
+        run: |
+          cd packages/react-native-brownfield
+          yarn test
+
   android-androidapp-expo:
     name: Android road test (AndroidApp - Expo ${{ matrix.version }})
     runs-on: ubuntu-latest

--- a/apps/RNApp/android/build.gradle
+++ b/apps/RNApp/android/build.gradle
@@ -16,7 +16,7 @@ buildscript {
         classpath("com.android.tools.build:gradle")
         classpath("com.facebook.react:react-native-gradle-plugin")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin")
-        classpath("com.callstack.react:brownfield-gradle-plugin:2.0.0-alpha02-SNAPSHOT")
+        classpath("com.callstack.react:brownfield-gradle-plugin:2.0.0-alpha03-SNAPSHOT")
     }
 }
 

--- a/apps/scripts/prepare-android-build-gradle-for-ci.ts
+++ b/apps/scripts/prepare-android-build-gradle-for-ci.ts
@@ -9,7 +9,7 @@ if (!projectDirName) {
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const SNAPSHOT_VERSION = '2.0.0-alpha02-SNAPSHOT';
+const SNAPSHOT_VERSION = '2.0.0-alpha03-SNAPSHOT';
 const targetPath = path.resolve(
   __dirname,
   '..',

--- a/gradle-plugins/react/brownfield/gradle.properties
+++ b/gradle-plugins/react/brownfield/gradle.properties
@@ -1,6 +1,6 @@
 PROJECT_ID=com.callstack.react.brownfield
 ARTIFACT_ID=brownfield-gradle-plugin
-VERSION=2.0.0-alpha02
+VERSION=2.0.0-alpha03
 GROUP=com.callstack.react
 IMPLEMENTATION_CLASS=com.callstack.react.brownfield.plugin.RNBrownfieldPlugin
 

--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/plugin/RNSourceSets.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/plugin/RNSourceSets.kt
@@ -55,25 +55,33 @@ object RNSourceSets {
                     isDebuggable = variant.debuggable,
                 )
             val capitalizedBundledAssetsVariantName = bundledAssetsVariantName.capitalized()
+            val appProject = getAppProject()
 
             // 3. Lazily configure the 'variant-specific' source set using .named()
             androidExtension.sourceSets.named(variantName) { sourceSet ->
-                // Paths are collected and added, similar to your improved version
                 val bundlePathSegments =
                     listOf(
                         // outputs for RN <= 0.81
                         "createBundle${capitalizedBundledAssetsVariantName}JsAndAssets",
                         // outputs for RN >= 0.82
                         "react/$bundledAssetsVariantName",
-                        // expo update resources
-                        "create${capitalizedBundledAssetsVariantName}UpdatesResources",
                     )
+                val updateResourcesPathSegment = Utils.getExpoUpdatesResourcesTaskName(variant.name)
 
                 // Add the variant-specific generated asset and resource directories
                 val appBuildDir = getAppBuildDir()
                 sourceSet.assets.srcDirs(bundlePathSegments.map { "$appBuildDir/generated/assets/$it" })
                 sourceSet.res.srcDirs(bundlePathSegments.map { "$appBuildDir/generated/res/$it" })
                 sourceSet.jniLibs.srcDirs("libs${variantName.capitalized()}")
+                if (Utils.hasExpoUpdates(appProject, variant.name)) {
+                    val updateResourcesTask = appProject.tasks.named(updateResourcesPathSegment)
+                    sourceSet.assets.srcDir(
+                        project.files("$appBuildDir/generated/assets/$updateResourcesPathSegment").builtBy(updateResourcesTask),
+                    )
+                    sourceSet.res.srcDir(
+                        project.files("$appBuildDir/generated/res/$updateResourcesPathSegment").builtBy(updateResourcesTask),
+                    )
+                }
             }
         }
     }

--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/processors/VariantTaskProvider.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/processors/VariantTaskProvider.kt
@@ -98,14 +98,10 @@ class VariantTaskProvider(val project: Project) {
             val updatesResourcesTaskName =
                 "create${capitalizedBundledAssetsVariantName}UpdatesResources"
 
-            appProject.tasks.findByName(updatesResourcesTaskName)?.let { updatesTask ->
+            appProject.tasks
+            .matching { it.name == updatesResourcesTaskName }
+            .configureEach { updatesTask ->
                 preBuildTask.dependsOn(updatesTask)
-            }
-
-            appProject.tasks.whenTaskAdded { task ->
-                if (task.name == updatesResourcesTaskName) {
-                    preBuildTask.dependsOn(task)
-                }
             }
         }
     }

--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/processors/VariantTaskProvider.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/processors/VariantTaskProvider.kt
@@ -95,13 +95,9 @@ class VariantTaskProvider(val project: Project) {
         preBuildTask.dependsOn("${appProject.path}:createBundle${capitalizedBundledAssetsVariantName}JsAndAssets")
 
         if (Utils.isExpoProject(project)) {
-            val updatesResourcesTaskName =
-                "create${capitalizedBundledAssetsVariantName}UpdatesResources"
-
-            appProject.tasks
-            .matching { it.name == updatesResourcesTaskName }
-            .configureEach { updatesTask ->
-                preBuildTask.dependsOn(updatesTask)
+            val updatesResourcesTaskName = Utils.getExpoUpdatesResourcesTaskName(variantName)
+            if (Utils.hasExpoUpdates(appProject, variantName)) {
+                preBuildTask.dependsOn("${appProject.path}:$updatesResourcesTaskName")
             }
         }
     }

--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/processors/VariantTaskProvider.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/processors/VariantTaskProvider.kt
@@ -95,9 +95,18 @@ class VariantTaskProvider(val project: Project) {
         preBuildTask.dependsOn("${appProject.path}:createBundle${capitalizedBundledAssetsVariantName}JsAndAssets")
 
         if (Utils.isExpoProject(project)) {
-            preBuildTask.dependsOn(
-                "${appProject.path}:create${capitalizedBundledAssetsVariantName}UpdatesResources",
-            )
+            val updatesResourcesTaskName =
+                "create${capitalizedBundledAssetsVariantName}UpdatesResources"
+
+            appProject.tasks.findByName(updatesResourcesTaskName)?.let { updatesTask ->
+                preBuildTask.dependsOn(updatesTask)
+            }
+
+            appProject.tasks.whenTaskAdded { task ->
+                if (task.name == updatesResourcesTaskName) {
+                    preBuildTask.dependsOn(task)
+                }
+            }
         }
     }
 }

--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/utils/Utils.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/utils/Utils.kt
@@ -28,6 +28,20 @@ object Utils {
         return project.findProject(EXPO_PROJECT_LOCATOR) != null
     }
 
+    fun getExpoUpdatesResourcesTaskName(variantName: String): String {
+        return "create${variantName.capitalized()}UpdatesResources"
+    }
+
+    fun hasExpoUpdates(
+        project: Project,
+        variantName: String,
+    ): Boolean {
+        return isExpoProject(project) &&
+            project.tasks.names.contains(
+                getExpoUpdatesResourcesTaskName(variantName),
+            )
+    }
+
     fun getBundledAssetsVariantName(
         variantName: String?,
         buildTypeName: String?,

--- a/packages/cli/src/brownfield/utils/__tests__/strip-framework-binary.test.ts
+++ b/packages/cli/src/brownfield/utils/__tests__/strip-framework-binary.test.ts
@@ -65,76 +65,91 @@ describe('stripFrameworkBinary', () => {
     );
   });
 
-  it('strips binary from ios-arm64 slice', () => {
-    const xcframeworkPath = createMockXcframework(tempDir, 'TestFramework', [
-      'ios-arm64',
-    ]);
-    const binaryPath = path.join(
-      xcframeworkPath,
-      'ios-arm64',
-      'TestFramework.framework',
-      'TestFramework'
-    );
-    const originalContent = fs.readFileSync(binaryPath, 'utf-8');
+  describe.skipIf(process.platform !== 'darwin')('with Xcode toolchain', () => {
+    it('strips binary from ios-arm64 slice', () => {
+      const xcframeworkPath = createMockXcframework(tempDir, 'TestFramework', [
+        'ios-arm64',
+      ]);
+      const binaryPath = path.join(
+        xcframeworkPath,
+        'ios-arm64',
+        'TestFramework.framework',
+        'TestFramework'
+      );
+      const originalContent = fs.readFileSync(binaryPath, 'utf-8');
 
-    stripFrameworkBinary(xcframeworkPath);
+      stripFrameworkBinary(xcframeworkPath);
 
-    const newContent = fs.readFileSync(binaryPath);
-    expect(newContent.toString()).not.toBe(originalContent);
-    expect(fs.existsSync(binaryPath)).toBe(true);
-    expect(mockLoggerSuccess).toHaveBeenCalledWith(
-      'TestFramework.xcframework is now interface-only'
-    );
-  });
-
-  it('strips binary from simulator slice with fat binary', () => {
-    const xcframeworkPath = createMockXcframework(tempDir, 'TestFramework', [
-      'ios-arm64_x86_64-simulator',
-    ]);
-    const binaryPath = path.join(
-      xcframeworkPath,
-      'ios-arm64_x86_64-simulator',
-      'TestFramework.framework',
-      'TestFramework'
-    );
-    const originalContent = fs.readFileSync(binaryPath, 'utf-8');
-
-    stripFrameworkBinary(xcframeworkPath);
-
-    const newContent = fs.readFileSync(binaryPath);
-    expect(newContent.toString()).not.toBe(originalContent);
-
-    const archInfo = execSync(`xcrun lipo -info "${binaryPath}"`, {
-      encoding: 'utf-8',
+      const newContent = fs.readFileSync(binaryPath);
+      expect(newContent.toString()).not.toBe(originalContent);
+      expect(fs.existsSync(binaryPath)).toBe(true);
+      expect(mockLoggerSuccess).toHaveBeenCalledWith(
+        'TestFramework.xcframework is now interface-only'
+      );
     });
-    expect(archInfo).toContain('arm64');
-    expect(archInfo).toContain('x86_64');
-  });
 
-  it('handles multiple slices', () => {
-    const xcframeworkPath = createMockXcframework(tempDir, 'TestFramework', [
-      'ios-arm64',
-      'ios-arm64_x86_64-simulator',
-    ]);
+    it('strips binary from simulator slice with fat binary', () => {
+      const xcframeworkPath = createMockXcframework(tempDir, 'TestFramework', [
+        'ios-arm64_x86_64-simulator',
+      ]);
+      const binaryPath = path.join(
+        xcframeworkPath,
+        'ios-arm64_x86_64-simulator',
+        'TestFramework.framework',
+        'TestFramework'
+      );
+      const originalContent = fs.readFileSync(binaryPath, 'utf-8');
 
-    stripFrameworkBinary(xcframeworkPath);
+      stripFrameworkBinary(xcframeworkPath);
 
-    const deviceBinary = path.join(
-      xcframeworkPath,
-      'ios-arm64',
-      'TestFramework.framework',
-      'TestFramework'
-    );
-    const simBinary = path.join(
-      xcframeworkPath,
-      'ios-arm64_x86_64-simulator',
-      'TestFramework.framework',
-      'TestFramework'
-    );
+      const newContent = fs.readFileSync(binaryPath);
+      expect(newContent.toString()).not.toBe(originalContent);
 
-    expect(fs.existsSync(deviceBinary)).toBe(true);
-    expect(fs.existsSync(simBinary)).toBe(true);
-    expect(mockLoggerSuccess).toHaveBeenCalledOnce();
+      const archInfo = execSync(`xcrun lipo -info "${binaryPath}"`, {
+        encoding: 'utf-8',
+      });
+      expect(archInfo).toContain('arm64');
+      expect(archInfo).toContain('x86_64');
+    });
+
+    it('handles multiple slices', () => {
+      const xcframeworkPath = createMockXcframework(tempDir, 'TestFramework', [
+        'ios-arm64',
+        'ios-arm64_x86_64-simulator',
+      ]);
+
+      stripFrameworkBinary(xcframeworkPath);
+
+      const deviceBinary = path.join(
+        xcframeworkPath,
+        'ios-arm64',
+        'TestFramework.framework',
+        'TestFramework'
+      );
+      const simBinary = path.join(
+        xcframeworkPath,
+        'ios-arm64_x86_64-simulator',
+        'TestFramework.framework',
+        'TestFramework'
+      );
+
+      expect(fs.existsSync(deviceBinary)).toBe(true);
+      expect(fs.existsSync(simBinary)).toBe(true);
+      expect(mockLoggerSuccess).toHaveBeenCalledOnce();
+    });
+
+    it('ignores non-ios directories', () => {
+      const xcframeworkPath = createMockXcframework(tempDir, 'TestFramework', [
+        'ios-arm64',
+      ]);
+      fs.mkdirSync(path.join(xcframeworkPath, 'macos-arm64'), {
+        recursive: true,
+      });
+
+      stripFrameworkBinary(xcframeworkPath);
+
+      expect(mockLoggerSuccess).toHaveBeenCalledOnce();
+    });
   });
 
   it('warns and skips unknown slice types', () => {
@@ -163,18 +178,5 @@ describe('stripFrameworkBinary', () => {
     expect(mockLoggerWarn).toHaveBeenCalledWith(
       expect.stringContaining('No binary found at')
     );
-  });
-
-  it('ignores non-ios directories', () => {
-    const xcframeworkPath = createMockXcframework(tempDir, 'TestFramework', [
-      'ios-arm64',
-    ]);
-    fs.mkdirSync(path.join(xcframeworkPath, 'macos-arm64'), {
-      recursive: true,
-    });
-
-    stripFrameworkBinary(xcframeworkPath);
-
-    expect(mockLoggerSuccess).toHaveBeenCalledOnce();
   });
 });

--- a/packages/react-native-brownfield/src/expo-config-plugin/android/utils/constants.ts
+++ b/packages/react-native-brownfield/src/expo-config-plugin/android/utils/constants.ts
@@ -1,2 +1,2 @@
-export const BROWNFIELD_PLUGIN_VERSION = '2.0.0-alpha02';
+export const BROWNFIELD_PLUGIN_VERSION = '2.0.0-alpha03';
 export const brownfieldGradlePluginDependency = `classpath("com.callstack.react:brownfield-gradle-plugin:${BROWNFIELD_PLUGIN_VERSION}")`;

--- a/scripts/__tests__/generate-brownfield-gradle-plugin-release-notes.test.ts
+++ b/scripts/__tests__/generate-brownfield-gradle-plugin-release-notes.test.ts
@@ -25,14 +25,14 @@ test('supports prerelease versions when finding the previous plugin tag', () => 
   const previousTag = findPreviousPluginTag(
     [
       'brownfield-gradle-plugin/v2.0.0-alpha01',
-      'brownfield-gradle-plugin/v2.0.0-alpha02',
+      'brownfield-gradle-plugin/v2.0.0-alpha03',
       'brownfield-gradle-plugin/v2.0.0-beta01',
       'brownfield-gradle-plugin/v2.0.0',
     ],
     '2.0.0-beta01'
   );
 
-  assert.equal(previousTag, 'brownfield-gradle-plugin/v2.0.0-alpha02');
+  assert.equal(previousTag, 'brownfield-gradle-plugin/v2.0.0-alpha03');
 });
 
 test('treats a stable release as newer than its prereleases', () => {
@@ -58,7 +58,8 @@ test('renders scoped release notes grouped by commit category', () => {
     },
     {
       hash: 'dd8b8a0',
-      subject: 'fix: broken support for custom `appProjectName` in Gradle Plugin (#275)',
+      subject:
+        'fix: broken support for custom `appProjectName` in Gradle Plugin (#275)',
     },
     {
       hash: '6ea8da9',


### PR DESCRIPTION


<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

If using Expo and `expo-updates` is absent, the following error will be thrown:
```
■  * What went wrong:
│  Could not determine the dependencies of task ':brownfieldlib:preReleaseBuild'.
│  > Task with path ':app:createReleaseUpdatesResources' not found in project ':brownfieldlib'.
```

The solution is to depend on it only if it exists to cover use cases without expo-updates.
