### PR TITLE
fix(ci): resolve changesets failing on CI due to cached faulty NodeJS version

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -19,6 +19,7 @@ runs:
       uses: actions/setup-node@65d868f8d4d85d7d4abb7de0875cde3fcc8798f5 # v6
       with:
         node-version: 'lts/*'
+        check-latest: true
         cache: 'yarn'
 
     - name: Setup Node.js (no cache)
@@ -26,6 +27,7 @@ runs:
       uses: actions/setup-node@65d868f8d4d85d7d4abb7de0875cde3fcc8798f5 # v6
       with:
         node-version: 'lts/*'
+        check-latest: true
         package-manager-cache: false
 
     - name: Restore Turbo cache


### PR DESCRIPTION
### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
This PR forces the setup-node action to pull in the most recent LTS version, which contains a fix for https://github.com/nodejs/node/issues/63989 .

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
CI green.