### PR TITLE
fix: duplicate .so resources on cold builds

### DIFF
--- a/.changeset/plenty-camels-pay.md
+++ b/.changeset/plenty-camels-pay.md
@@ -1,0 +1,5 @@
+---
+'@callstack/react-native-brownfield': patch
+---
+
+fix: duplicated JNI libs on cold publish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
       expo56: ${{ steps.filter.outputs.expo56 }}
       androidapp: ${{ steps.filter.outputs.androidapp }}
       appleapp: ${{ steps.filter.outputs.appleapp }}
+      gradle-plugins: ${{ steps.filter.outputs.gradle-plugins }}
       ci: ${{ steps.filter.outputs.ci }}
     steps:
       - name: Checkout
@@ -52,6 +53,8 @@ jobs:
             appleapp:
               - 'apps/AppleApp/**'
               - 'apps/brownfield-example-shared-tests/**'
+            gradle-plugins:
+              - 'gradle-plugins/**'
             ci:
               - '.github/**'
 
@@ -139,6 +142,7 @@ jobs:
         needs.filter.outputs.expo56 == 'true' ||
         needs.filter.outputs.androidapp == 'true' ||
         needs.filter.outputs.packages == 'true' ||
+        needs.filter.outputs.gradle-plugins == 'true' ||
         needs.filter.outputs.ci == 'true'
       ) &&
       (needs.build-lint.result == 'success' || needs.build-lint.result == 'skipped')
@@ -169,6 +173,7 @@ jobs:
         needs.filter.outputs.rnapp == 'true' ||
         needs.filter.outputs.androidapp == 'true' ||
         needs.filter.outputs.packages == 'true' ||
+        needs.filter.outputs.gradle-plugins == 'true' ||
         needs.filter.outputs.ci == 'true'
       ) &&
       (needs.build-lint.result == 'success' || needs.build-lint.result == 'skipped')

--- a/apps/RNApp/android/build.gradle
+++ b/apps/RNApp/android/build.gradle
@@ -16,7 +16,7 @@ buildscript {
         classpath("com.android.tools.build:gradle")
         classpath("com.facebook.react:react-native-gradle-plugin")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin")
-        classpath("com.callstack.react:brownfield-gradle-plugin:2.0.0-alpha04-SNAPSHOT")
+        classpath("com.callstack.react:brownfield-gradle-plugin:2.0.0-alpha05-SNAPSHOT")
     }
 }
 

--- a/apps/scripts/prepare-android-build-gradle-for-ci.ts
+++ b/apps/scripts/prepare-android-build-gradle-for-ci.ts
@@ -9,7 +9,7 @@ if (!projectDirName) {
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const SNAPSHOT_VERSION = '2.0.0-alpha04-SNAPSHOT';
+const SNAPSHOT_VERSION = '2.0.0-alpha05-SNAPSHOT';
 const targetPath = path.resolve(
   __dirname,
   '..',

--- a/gradle-plugins/react/brownfield/gradle.properties
+++ b/gradle-plugins/react/brownfield/gradle.properties
@@ -1,6 +1,6 @@
 PROJECT_ID=com.callstack.react.brownfield
 ARTIFACT_ID=brownfield-gradle-plugin
-VERSION=2.0.0-alpha04
+VERSION=2.0.0-alpha05
 GROUP=com.callstack.react
 IMPLEMENTATION_CLASS=com.callstack.react.brownfield.plugin.RNBrownfieldPlugin
 

--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/plugin/RNSourceSets.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/plugin/RNSourceSets.kt
@@ -71,7 +71,14 @@ object RNSourceSets {
                 val appBuildDir = getAppBuildDir()
                 sourceSet.assets.srcDirs(bundlePathSegments.map { "$appBuildDir/generated/assets/$it" })
                 sourceSet.res.srcDirs(bundlePathSegments.map { "$appBuildDir/generated/res/$it" })
-                sourceSet.jniLibs.srcDirs("libs${variantName.capitalized()}")
+                if (extension.useStrippedSoFiles) {
+                    val capitalizedVariantName = variantName.capitalized()
+                    val libsDir = project.layout.projectDirectory.dir("libs$capitalizedVariantName")
+                    val copyTaskName = "copy${capitalizedVariantName}LibSources"
+                    sourceSet.jniLibs.srcDir(
+                        project.files(libsDir).builtBy(copyTaskName),
+                    )
+                }
                 if (Utils.hasExpoUpdates(appProject, variant.name)) {
                     val updateResourcesTask = appProject.tasks.named(updateResourcesPathSegment)
                     sourceSet.assets.srcDir(

--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/processors/JNILibsProcessor.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/processors/JNILibsProcessor.kt
@@ -25,11 +25,9 @@ class JNILibsProcessor(val project: Project) {
         }
 
         val androidExtension = project.extensions.getByName("android") as LibraryExtension
-        val copyTask = copySoLibsTask(variantName)
+        copySoLibsTask(variantName)
 
         mergeJniLibsTask.configure {
-            it.dependsOn(copyTask)
-
             it.doFirst {
                 val projectExt = project.extensions.getByType(Extension::class.java)
                 val existingJNILibs =

--- a/packages/react-native-brownfield/src/expo-config-plugin/android/__tests__/gradleHelpers.test.ts
+++ b/packages/react-native-brownfield/src/expo-config-plugin/android/__tests__/gradleHelpers.test.ts
@@ -16,7 +16,7 @@ describe('gradleHelpers', () => {
 }`;
 
     expect(modifyRootBuildGradle(contents)).toContain(
-      'classpath("com.callstack.react:brownfield-gradle-plugin:2.0.0-alpha04")'
+      'classpath("com.callstack.react:brownfield-gradle-plugin:2.0.0-alpha05")'
     );
   });
 

--- a/packages/react-native-brownfield/src/expo-config-plugin/android/utils/constants.ts
+++ b/packages/react-native-brownfield/src/expo-config-plugin/android/utils/constants.ts
@@ -1,2 +1,2 @@
-export const BROWNFIELD_PLUGIN_VERSION = '2.0.0-alpha04';
+export const BROWNFIELD_PLUGIN_VERSION = '2.0.0-alpha05';
 export const brownfieldGradlePluginDependency = `classpath("com.callstack.react:brownfield-gradle-plugin:${BROWNFIELD_PLUGIN_VERSION}")`;

--- a/scripts/__tests__/generate-brownfield-gradle-plugin-release-notes.test.ts
+++ b/scripts/__tests__/generate-brownfield-gradle-plugin-release-notes.test.ts
@@ -25,14 +25,14 @@ test('supports prerelease versions when finding the previous plugin tag', () => 
   const previousTag = findPreviousPluginTag(
     [
       'brownfield-gradle-plugin/v2.0.0-alpha01',
-      'brownfield-gradle-plugin/v2.0.0-alpha04',
+      'brownfield-gradle-plugin/v2.0.0-alpha05',
       'brownfield-gradle-plugin/v2.0.0-beta01',
       'brownfield-gradle-plugin/v2.0.0',
     ],
     '2.0.0-beta01'
   );
 
-  assert.equal(previousTag, 'brownfield-gradle-plugin/v2.0.0-alpha04');
+  assert.equal(previousTag, 'brownfield-gradle-plugin/v2.0.0-alpha05');
 });
 
 test('treats a stable release as newer than its prereleases', () => {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Fixes a first-run failure when publishing the brownfield AAR (`publishToMavenLocal` / `brownfield publish:android`) with `Resource and asset merger: Duplicate resources` errors for .so files in `libsDebug` / `libsRelease`.

#### Problem
With useStrippedSoFiles enabled (default), native libraries are staged into `libs<Variant>` (e.g. `libsDebug`) by `copy<Variant>LibSources`, and that folder is also registered as a JNI source directory for `merge<Variant>JniLibFolders`.

On a cold build, Gradle saw the same directory twice in the merge inputs:
- as a static `jniLibs.srcDirs("libsDebug")` entry
- again via `mergeJniLibFolders.dependsOn(copyDebugLibSources)`, which writes to the same path

That produced duplicate-resource errors for every .so file. A second publish often succeeded because the copy task was `UP-TO-DATE` and the input wiring differed.

#### Fix
- `RNSourceSets.kt`: register JNI libs via `project.files(libsDir).builtBy(copy<Variant>LibSources)` instead of a static `srcDirs(...)`, matching how Expo updates assets are wired,
- `JNILibsProcessor.kt`: remove the redundant `dependsOn(copyTask)` on `mergeJniLibFolders`; task ordering is now handled by `builtBy`.

This ensures `libs<Variant>` is included once in the JNI merge inputs while preserving the existing copy + `copyStrippedSoLibs` behavior.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
CI green.