### PR TITLE
fix: wire merge classes to asm transformer

### DIFF
--- a/.changeset/open-zoos-walk.md
+++ b/.changeset/open-zoos-walk.md
@@ -1,0 +1,5 @@
+---
+'@callstack/react-native-brownfield': patch
+---
+
+fix: merge classes to contain third party libs classes

--- a/apps/RNApp/android/build.gradle
+++ b/apps/RNApp/android/build.gradle
@@ -16,7 +16,7 @@ buildscript {
         classpath("com.android.tools.build:gradle")
         classpath("com.facebook.react:react-native-gradle-plugin")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin")
-        classpath("com.callstack.react:brownfield-gradle-plugin:2.0.0-alpha05-SNAPSHOT")
+        classpath("com.callstack.react:brownfield-gradle-plugin:2.0.0-alpha06-SNAPSHOT")
     }
 }
 

--- a/apps/RNApp/package.json
+++ b/apps/RNApp/package.json
@@ -7,7 +7,7 @@
     "ios": "yarn brownfield:package:ios && brownfield codegen && react-native run-ios",
     "build:example:android-rn": "react-native build-android",
     "build:example:ios-rn": "react-native build-ios",
-    "brownfield:package:android": "brownfield package:android --variant release",
+    "brownfield:package:android": "brownfield package:android",
     "brownfield:publish:android": "brownfield publish:android",
     "brownfield:package:ios": "brownfield package:ios --configuration Release",
     "lint": "eslint .",

--- a/apps/scripts/prepare-android-build-gradle-for-ci.ts
+++ b/apps/scripts/prepare-android-build-gradle-for-ci.ts
@@ -9,7 +9,7 @@ if (!projectDirName) {
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const SNAPSHOT_VERSION = '2.0.0-alpha05-SNAPSHOT';
+const SNAPSHOT_VERSION = '2.0.0-alpha06-SNAPSHOT';
 const targetPath = path.resolve(
   __dirname,
   '..',

--- a/gradle-plugins/react/brownfield/gradle.properties
+++ b/gradle-plugins/react/brownfield/gradle.properties
@@ -1,6 +1,6 @@
 PROJECT_ID=com.callstack.react.brownfield
 ARTIFACT_ID=brownfield-gradle-plugin
-VERSION=2.0.0-alpha05
+VERSION=2.0.0-alpha06
 GROUP=com.callstack.react
 IMPLEMENTATION_CLASS=com.callstack.react.brownfield.plugin.RNBrownfieldPlugin
 

--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/plugin/RNBrownfieldPlugin.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/plugin/RNBrownfieldPlugin.kt
@@ -11,6 +11,7 @@ import com.callstack.react.brownfield.processors.JNILibsProcessor
 import com.callstack.react.brownfield.processors.ManifestTaskProcessor
 import com.callstack.react.brownfield.processors.ProguardProcessor
 import com.callstack.react.brownfield.processors.ResourceTaskProcessor
+import com.callstack.react.brownfield.processors.VariantHelper
 import com.callstack.react.brownfield.processors.VariantPackagesProperty
 import com.callstack.react.brownfield.processors.VariantTaskProvider
 import com.callstack.react.brownfield.shared.BaseProject
@@ -138,6 +139,12 @@ class RNBrownfieldPlugin : Plugin<Project> {
         )
 
         val aarLibraries = getAarLibraries(artifacts, variantName)
+
+        /** =======  MERGE CLASSES  =========*/
+        val mergeClassesTask = variantTaskProvider.mergeClasses(aarLibraries, explodeTask, variantName)
+        project.tasks.named(VariantHelper.getAsmTransformTaskName(capitalizedVariantName)).configure {
+            it.dependsOn(mergeClassesTask)
+        }
 
         /**
          * Flat IDs to be put into the variant property, required for RClass Transformer

--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/plugin/RNSourceSets.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/plugin/RNSourceSets.kt
@@ -3,6 +3,7 @@ package com.callstack.react.brownfield.plugin
 import com.android.build.api.variant.LibraryAndroidComponentsExtension
 import com.android.build.gradle.LibraryExtension
 import com.callstack.react.brownfield.exceptions.NameSpaceNotFound
+import com.callstack.react.brownfield.processors.VariantHelper
 import com.callstack.react.brownfield.utils.Extension
 import com.callstack.react.brownfield.utils.Utils
 import com.callstack.react.brownfield.utils.capitalized
@@ -49,7 +50,7 @@ object RNSourceSets {
         componentsExtension.onVariants { variant ->
             val variantName = variant.name
             val bundledAssetsVariantName =
-                Utils.getBundledAssetsVariantName(
+                VariantHelper.getBundledAssetsVariantName(
                     variantName = variantName,
                     buildTypeName = variant.buildType,
                     isDebuggable = variant.debuggable,
@@ -66,7 +67,7 @@ object RNSourceSets {
                         // outputs for RN >= 0.82
                         "react/$bundledAssetsVariantName",
                     )
-                val updateResourcesPathSegment = Utils.getExpoUpdatesResourcesTaskName(variant.name)
+                val updateResourcesPathSegment = VariantHelper.getExpoUpdatesResourcesTaskName(variant.name)
 
                 val appBuildDir = getAppBuildDir()
                 sourceSet.assets.srcDirs(bundlePathSegments.map { "$appBuildDir/generated/assets/$it" })

--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/processors/ExplodeTaskProvider.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/processors/ExplodeTaskProvider.kt
@@ -26,7 +26,6 @@ object ExplodeTaskProvider {
             ExplodeAarTask::class.java,
         ) { task ->
             task.variantName.set(variant.name)
-            task.minifyEnabled.set(variant.buildType.isMinifyEnabled)
 
             val finalArtifacts = mutableListOf<UnresolvedArtifactInfo>()
             artifacts.forEach { art ->

--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/processors/MergeProcessor.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/processors/MergeProcessor.kt
@@ -5,19 +5,12 @@ import org.gradle.api.Project
 import java.io.File
 
 object MergeProcessor {
-    fun mergeClassesJarIntoClasses(
+    fun mergeClassesJarFilesIntoClasses(
         project: Project,
-        androidLibraries: Collection<AndroidArchiveLibrary>,
+        classJarFiles: Collection<File>,
         folderOut: File,
     ) {
-        val allJarFiles: MutableCollection<File> = ArrayList()
-        val filteredLibs = getFilteredAarLibs(androidLibraries)
-        filteredLibs.forEach {
-            allJarFiles.add(it.getClassesJarFile())
-        }
-
-        val filteredAllJarFiles = allJarFiles.filter { it.exists() }
-        filteredAllJarFiles.forEach { jarFile ->
+        classJarFiles.filter { it.exists() }.forEach { jarFile ->
             project.copy {
                 it.from(project.zipTree(jarFile))
                 it.into(folderOut)
@@ -25,28 +18,13 @@ object MergeProcessor {
         }
     }
 
-    fun mergeLibsIntoClasses(
+    fun mergeClassesJarIntoClasses(
         project: Project,
         androidLibraries: Collection<AndroidArchiveLibrary>,
-        jarFiles: Collection<File>,
-        outputDir: File,
+        folderOut: File,
     ) {
-        val allJarFiles: MutableCollection<File> = ArrayList()
-        val filteredLibs = getFilteredAarLibs(androidLibraries)
-        filteredLibs.forEach {
-            allJarFiles.addAll(it.getLocalJars())
-        }
-
-        val filteredJarFiles = jarFiles.filter { it.exists() }
-        filteredJarFiles.forEach { allJarFiles.add(it) }
-
-        allJarFiles.forEach { jarFile ->
-            project.copy {
-                it.from(project.zipTree(jarFile))
-                it.into(outputDir)
-                it.exclude("META-INF/")
-            }
-        }
+        val classesJarFiles = getFilteredAarLibs(androidLibraries).map { it.getClassesJarFile() }
+        mergeClassesJarFilesIntoClasses(project, classesJarFiles, folderOut)
     }
 
     private fun getFilteredAarLibs(androidLibraries: Collection<AndroidArchiveLibrary>): Collection<AndroidArchiveLibrary> {

--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/processors/VariantHelper.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/processors/VariantHelper.kt
@@ -1,61 +1,42 @@
 package com.callstack.react.brownfield.processors
 
-import com.callstack.react.brownfield.shared.BaseProject
-import com.callstack.react.brownfield.utils.AndroidArchiveLibrary
-import com.callstack.react.brownfield.utils.DirectoryManager
 import com.callstack.react.brownfield.utils.capitalized
-import org.gradle.api.file.ConfigurableFileCollection
-import java.io.File
-import java.nio.file.Files
-import java.nio.file.Path
-import java.nio.file.Paths
 
-class VariantHelper : BaseProject() {
-    private fun getClassPathDirFiles(variantName: String): ConfigurableFileCollection {
-        return project.files(
-            "$buildDir/intermediates/javac/$variantName/compile${variantName.capitalized()}JavaWithJavac/classes",
-        )
+object VariantHelper {
+    fun getAsmTransformTaskName(capitalizedVariantName: String): String {
+        return "transform${capitalizedVariantName}ClassesWithAsm"
     }
 
-    fun classesMergeTaskDoFirst(
-        outputDir: File,
-        variantName: String,
-    ) {
-        val pathsToDelete = mutableListOf<Path>()
-        val javacDir = getClassPathDirFiles(variantName).first()
-        project.fileTree(outputDir).forEach { path ->
-            pathsToDelete.add(
-                Paths.get(outputDir.absolutePath).relativize(Paths.get(path.absolutePath)),
-            )
+    fun getBundledAssetsVariantName(
+        variantName: String?,
+        buildTypeName: String?,
+        isDebuggable: Boolean,
+    ): String {
+        require(!variantName.isNullOrEmpty()) {
+            "getBundledAssetsVariantName: Variant name cannot be empty"
         }
-        outputDir.deleteRecursively()
-        pathsToDelete.forEach { path ->
-            Files.deleteIfExists(Paths.get("$javacDir.absolutePath/$path"))
+
+        require(!buildTypeName.isNullOrEmpty()) {
+            "getBundledAssetsVariantName: Build Type cannot be empty"
+        }
+
+        if (!isDebuggable) {
+            return variantName
+        }
+
+        if (variantName == buildTypeName) {
+            return "release"
+        }
+
+        val capitalizedBuildTypeName = buildTypeName.capitalized()
+        return if (variantName.endsWith(capitalizedBuildTypeName)) {
+            "${variantName.removeSuffix(capitalizedBuildTypeName)}Release"
+        } else {
+            "release"
         }
     }
 
-    fun classesMergeTaskDoLast(
-        outputDir: File,
-        aarLibraries: Collection<AndroidArchiveLibrary>,
-        jarFiles: MutableList<File>,
-        variantName: String,
-        isMinifyEnabled: Boolean,
-    ) {
-        MergeProcessor.mergeClassesJarIntoClasses(project, aarLibraries, outputDir)
-        if (isMinifyEnabled) {
-            MergeProcessor.mergeLibsIntoClasses(project, aarLibraries, jarFiles, outputDir)
-        }
-        val javacDir = getClassPathDirFiles(variantName).first()
-        project.copy { copyTask ->
-            copyTask.from(outputDir)
-            copyTask.into(javacDir)
-            copyTask.exclude("META-INF/")
-        }
-
-        project.copy { copyTask ->
-            copyTask.from("${outputDir.absolutePath}/META-INF")
-            copyTask.into(DirectoryManager.getKotlinMetaDirectory(variantName))
-            copyTask.include("*.kotlin_module")
-        }
+    fun getExpoUpdatesResourcesTaskName(variantName: String): String {
+        return "create${variantName.capitalized()}UpdatesResources"
     }
 }

--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/processors/VariantHelper.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/processors/VariantHelper.kt
@@ -1,6 +1,9 @@
 package com.callstack.react.brownfield.processors
 
 import com.callstack.react.brownfield.utils.capitalized
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.tasks.TaskCollection
 
 object VariantHelper {
     fun getAsmTransformTaskName(capitalizedVariantName: String): String {
@@ -38,5 +41,19 @@ object VariantHelper {
 
     fun getExpoUpdatesResourcesTaskName(variantName: String): String {
         return "create${variantName.capitalized()}UpdatesResources"
+    }
+
+    fun getKotlinCompileTask(
+        project: Project,
+        capitalizedVariantName: String,
+    ): TaskCollection<Task> {
+        return project.tasks.matching { it.name == "compile${capitalizedVariantName}Kotlin" }
+    }
+
+    fun getJavaCompileTask(
+        project: Project,
+        capitalizedVariantName: String,
+    ): TaskCollection<Task> {
+        return project.tasks.matching { it.name == "compile${capitalizedVariantName}JavaWithJavac" }
     }
 }

--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/processors/VariantTaskProvider.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/processors/VariantTaskProvider.kt
@@ -13,7 +13,6 @@ import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.UnknownTaskException
 import org.gradle.api.tasks.TaskProvider
-import org.gradle.configurationcache.extensions.capitalized
 import java.io.File
 
 class VariantTaskProvider(val project: Project) {
@@ -111,11 +110,11 @@ class VariantTaskProvider(val project: Project) {
     ): TaskProvider<MergeClassesTask> {
         val capitalizedVariantName = variantName.capitalized()
         val mergeClassesTaskName = "mergeClasses$capitalizedVariantName"
-        val kotlinCompileTaskName = "compile${capitalizedVariantName}Kotlin"
 
         return project.tasks.register(mergeClassesTaskName, MergeClassesTask::class.java) {
             it.dependsOn(explodeTasks)
-            it.dependsOn(project.tasks.named(kotlinCompileTaskName))
+            it.dependsOn(VariantHelper.getKotlinCompileTask(project, capitalizedVariantName))
+            it.dependsOn(VariantHelper.getJavaCompileTask(project, capitalizedVariantName))
             it.variantName.set(variantName)
             it.inputClassesJars.from(aarLibraries.map { aarLibrary -> aarLibrary.getClassesJarFile() })
             it.outputDir.set(DirectoryManager.getMergeClassDirectory(variantName))

--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/processors/VariantTaskProvider.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/processors/VariantTaskProvider.kt
@@ -3,6 +3,7 @@ package com.callstack.react.brownfield.processors
 import com.android.build.gradle.internal.tasks.factory.dependsOn
 import com.callstack.react.brownfield.exceptions.TaskNotFound
 import com.callstack.react.brownfield.shared.ExplodeAarTask
+import com.callstack.react.brownfield.shared.MergeClassesTask
 import com.callstack.react.brownfield.utils.AndroidArchiveLibrary
 import com.callstack.react.brownfield.utils.DirectoryManager
 import com.callstack.react.brownfield.utils.Extension
@@ -12,6 +13,7 @@ import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.UnknownTaskException
 import org.gradle.api.tasks.TaskProvider
+import org.gradle.configurationcache.extensions.capitalized
 import java.io.File
 
 class VariantTaskProvider(val project: Project) {
@@ -83,7 +85,7 @@ class VariantTaskProvider(val project: Project) {
         preBuildTask.dependsOn(explodeAarTask)
 
         val bundledAssetsVariantName =
-            Utils.getBundledAssetsVariantName(
+            VariantHelper.getBundledAssetsVariantName(
                 variantName = variantName,
                 buildTypeName = buildTypeName,
                 isDebuggable = isVariantDebuggable,
@@ -95,10 +97,28 @@ class VariantTaskProvider(val project: Project) {
         preBuildTask.dependsOn("${appProject.path}:createBundle${capitalizedBundledAssetsVariantName}JsAndAssets")
 
         if (Utils.isExpoProject(project)) {
-            val updatesResourcesTaskName = Utils.getExpoUpdatesResourcesTaskName(variantName)
+            val updatesResourcesTaskName = VariantHelper.getExpoUpdatesResourcesTaskName(variantName)
             if (Utils.hasExpoUpdates(appProject, variantName)) {
                 preBuildTask.dependsOn("${appProject.path}:$updatesResourcesTaskName")
             }
+        }
+    }
+
+    fun mergeClasses(
+        aarLibraries: Collection<AndroidArchiveLibrary>,
+        explodeTasks: TaskProvider<ExplodeAarTask>,
+        variantName: String,
+    ): TaskProvider<MergeClassesTask> {
+        val capitalizedVariantName = variantName.capitalized()
+        val mergeClassesTaskName = "mergeClasses$capitalizedVariantName"
+        val kotlinCompileTaskName = "compile${capitalizedVariantName}Kotlin"
+
+        return project.tasks.register(mergeClassesTaskName, MergeClassesTask::class.java) {
+            it.dependsOn(explodeTasks)
+            it.dependsOn(project.tasks.named(kotlinCompileTaskName))
+            it.variantName.set(variantName)
+            it.inputClassesJars.from(aarLibraries.map { aarLibrary -> aarLibrary.getClassesJarFile() })
+            it.outputDir.set(DirectoryManager.getMergeClassDirectory(variantName))
         }
     }
 }

--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/shared/ExplodeAarTask.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/shared/ExplodeAarTask.kt
@@ -1,8 +1,6 @@
 package com.callstack.react.brownfield.shared
 
-import com.callstack.react.brownfield.processors.VariantHelper
 import com.callstack.react.brownfield.utils.AndroidArchiveLibrary
-import com.callstack.react.brownfield.utils.DirectoryManager
 import org.gradle.api.DefaultTask
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
@@ -17,24 +15,10 @@ abstract class ExplodeAarTask : DefaultTask() {
     @get:Input
     abstract val variantName: Property<String>
 
-    @get:Input
-    abstract val minifyEnabled: Property<Boolean>
-
     @TaskAction
     fun run() {
         val artifacts = inputArtifacts.get()
         val resolvedVariantName = variantName.get()
-
-        val variantHelper = VariantHelper()
-        variantHelper.project = project
-
-        // classes-merge
-        variantHelper.classesMergeTaskDoFirst(
-            DirectoryManager.getMergeClassDirectory(
-                resolvedVariantName,
-            ),
-            resolvedVariantName,
-        )
 
         val aarLibraries = mutableListOf<AndroidArchiveLibrary>()
         artifacts.forEach { art ->
@@ -64,9 +48,5 @@ abstract class ExplodeAarTask : DefaultTask() {
                 it.into(zipFolder)
             }
         }
-
-        // classes-merge
-        val mergeClassesOutputDir = DirectoryManager.getMergeClassDirectory(resolvedVariantName)
-        variantHelper.classesMergeTaskDoLast(mergeClassesOutputDir, aarLibraries, mutableListOf(), resolvedVariantName, minifyEnabled.get())
     }
 }

--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/shared/MergeClassesTask.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/shared/MergeClassesTask.kt
@@ -1,0 +1,70 @@
+package com.callstack.react.brownfield.shared
+
+import com.callstack.react.brownfield.processors.MergeProcessor
+import com.callstack.react.brownfield.utils.DirectoryManager
+import com.callstack.react.brownfield.utils.capitalized
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Classpath
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+abstract class MergeClassesTask : DefaultTask() {
+    @get:Classpath
+    abstract val inputClassesJars: ConfigurableFileCollection
+
+    @get:Input
+    abstract val variantName: Property<String>
+
+    @get:OutputDirectory
+    abstract val outputDir: DirectoryProperty
+
+    @TaskAction
+    fun run() {
+        val resolvedVariantName = variantName.get()
+        val mergedOutputDir = outputDir.get().asFile
+        val javacDir = getClassPathDir(resolvedVariantName)
+        val pathsToDelete = mutableListOf<Path>()
+
+        if (mergedOutputDir.exists()) {
+            project.fileTree(mergedOutputDir).forEach { path ->
+                pathsToDelete.add(
+                    Paths.get(mergedOutputDir.absolutePath).relativize(Paths.get(path.absolutePath)),
+                )
+            }
+        }
+
+        mergedOutputDir.deleteRecursively()
+        pathsToDelete.forEach { path ->
+            Files.deleteIfExists(javacDir.toPath().resolve(path))
+        }
+
+        MergeProcessor.mergeClassesJarFilesIntoClasses(project, inputClassesJars.files, mergedOutputDir)
+
+        project.copy { copyTask ->
+            copyTask.from(mergedOutputDir)
+            copyTask.into(javacDir)
+            copyTask.exclude("META-INF/")
+        }
+
+        project.copy { copyTask ->
+            copyTask.from(File(mergedOutputDir, "META-INF"))
+            copyTask.into(DirectoryManager.getKotlinMetaDirectory(resolvedVariantName))
+            copyTask.include("*.kotlin_module")
+        }
+    }
+
+    private fun getClassPathDir(variantName: String): File {
+        val buildDirectory = project.layout.buildDirectory.get().asFile
+        return project.file(
+            "$buildDirectory/intermediates/javac/$variantName/compile${variantName.capitalized()}JavaWithJavac/classes",
+        )
+    }
+}

--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/utils/Utils.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/utils/Utils.kt
@@ -1,6 +1,7 @@
 package com.callstack.react.brownfield.utils
 
 import com.callstack.react.brownfield.plugin.RNBrownfieldPlugin.Companion.EXPO_PROJECT_LOCATOR
+import com.callstack.react.brownfield.processors.VariantHelper
 import org.gradle.api.Project
 import java.io.File
 
@@ -28,46 +29,13 @@ object Utils {
         return project.findProject(EXPO_PROJECT_LOCATOR) != null
     }
 
-    fun getExpoUpdatesResourcesTaskName(variantName: String): String {
-        return "create${variantName.capitalized()}UpdatesResources"
-    }
-
     fun hasExpoUpdates(
         project: Project,
         variantName: String,
     ): Boolean {
         return isExpoProject(project) &&
             project.tasks.names.contains(
-                getExpoUpdatesResourcesTaskName(variantName),
+                VariantHelper.getExpoUpdatesResourcesTaskName(variantName),
             )
-    }
-
-    fun getBundledAssetsVariantName(
-        variantName: String?,
-        buildTypeName: String?,
-        isDebuggable: Boolean,
-    ): String {
-        require(!variantName.isNullOrEmpty()) {
-            "getBundledAssetsVariantName: Variant name cannot be empty"
-        }
-
-        require(!buildTypeName.isNullOrEmpty()) {
-            "getBundledAssetsVariantName: Build Type cannot be empty"
-        }
-
-        if (!isDebuggable) {
-            return variantName
-        }
-
-        if (variantName == buildTypeName) {
-            return "release"
-        }
-
-        val capitalizedBuildTypeName = buildTypeName.capitalized()
-        return if (variantName.endsWith(capitalizedBuildTypeName)) {
-            "${variantName.removeSuffix(capitalizedBuildTypeName)}Release"
-        } else {
-            "release"
-        }
     }
 }

--- a/packages/react-native-brownfield/src/expo-config-plugin/android/__tests__/gradleHelpers.test.ts
+++ b/packages/react-native-brownfield/src/expo-config-plugin/android/__tests__/gradleHelpers.test.ts
@@ -16,7 +16,7 @@ describe('gradleHelpers', () => {
 }`;
 
     expect(modifyRootBuildGradle(contents)).toContain(
-      'classpath("com.callstack.react:brownfield-gradle-plugin:2.0.0-alpha05")'
+      'classpath("com.callstack.react:brownfield-gradle-plugin:2.0.0-alpha06")'
     );
   });
 

--- a/packages/react-native-brownfield/src/expo-config-plugin/android/utils/constants.ts
+++ b/packages/react-native-brownfield/src/expo-config-plugin/android/utils/constants.ts
@@ -1,2 +1,2 @@
-export const BROWNFIELD_PLUGIN_VERSION = '2.0.0-alpha05';
+export const BROWNFIELD_PLUGIN_VERSION = '2.0.0-alpha06';
 export const brownfieldGradlePluginDependency = `classpath("com.callstack.react:brownfield-gradle-plugin:${BROWNFIELD_PLUGIN_VERSION}")`;

--- a/scripts/__tests__/generate-brownfield-gradle-plugin-release-notes.test.ts
+++ b/scripts/__tests__/generate-brownfield-gradle-plugin-release-notes.test.ts
@@ -25,14 +25,14 @@ test('supports prerelease versions when finding the previous plugin tag', () => 
   const previousTag = findPreviousPluginTag(
     [
       'brownfield-gradle-plugin/v2.0.0-alpha01',
-      'brownfield-gradle-plugin/v2.0.0-alpha05',
+      'brownfield-gradle-plugin/v2.0.0-alpha06',
       'brownfield-gradle-plugin/v2.0.0-beta01',
       'brownfield-gradle-plugin/v2.0.0',
     ],
     '2.0.0-beta01'
   );
 
-  assert.equal(previousTag, 'brownfield-gradle-plugin/v2.0.0-alpha05');
+  assert.equal(previousTag, 'brownfield-gradle-plugin/v2.0.0-alpha06');
 });
 
 test('treats a stable release as newer than its prereleases', () => {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

This PR fixes a bug in which the final merged `classes.jar` did not contain the third party libraries. This bug was introduced after the BGP optimizations. We did not face any issues until now because running the `assemble` or `bundle` command after the first time, gets the final merged `classes.jar` to have the third party libraries.

In our usual flow, we first run `package:aar` and then `publish:aar`, so we did not face this issue, however as part of https://github.com/callstack/react-native-brownfield/pull/413 this issue became evident as Expo SDK 57 clears the native directories and regenerate those on each prebuild invocation.

To fix it, we bring back the code which was responsible to handle this. We create a custom `MergeClasses` task and wire it to be a dependency of `transformClassesWithAsm` gradle task.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

- Verified locally
- CI passes