### PR TITLE
chore: use changeset publish command

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:apps": "turbo run test --filter='./apps/*'",
     "dev": "yarn workspaces foreach -Api run dev",
     "ci:version": "changeset version && yarn install --no-immutable && node --experimental-strip-types --no-warnings ./scripts/consolidate-changelog.ts",
-    "ci:publish": "yarn workspaces foreach --no-private -At npm publish && changeset tag",
+    "ci:publish": "changeset publish",
     "brownfield:plugin:publish:local": "bash ./gradle-plugins/publish-to-maven-local.sh --skip-signing",
     "brownfield:plugin:publish:local:signed": "bash ./gradle-plugins/publish-to-maven-local.sh",
     "build:brownfield": "turbo run build:brownfield",


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
This PR replaces `npm publish` with `changeset publish` to prevent:
```➤ YN0035: You cannot publish over the previously published versions: 4.0.0.
➤ YN0035:   Response Code: 403 (Forbidden)
➤ YN0035:   Request Method: PUT
➤ YN0035:   Request URL: https://registry.yarnpkg.com/@callstack%2fbrownfield-cli
➤ YN0000: Failed with errors in 1s 732ms
```

e.g. on this run: https://github.com/callstack/react-native-brownfield/actions/runs/28857461435/job/85587457990

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
CI green