### PR TITLE
feat: allow extending the list of libs kept out of the AAR

### DIFF
--- a/.changeset/tidy-moons-shave.md
+++ b/.changeset/tidy-moons-shave.md
@@ -1,0 +1,7 @@
+---
+"@callstack/react-native-brownfield": patch
+---
+
+feat: allow extending the list of .so files kept out of the AAR
+
+Adds a `reactBrownfield.ignoreEmbeddedLibs` option so a project can name additional native libraries that should not be embedded, next to the built-in `IGNORE_EMBEDDED_LIBS` list.

--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/processors/JNILibsProcessor.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/processors/JNILibsProcessor.kt
@@ -9,6 +9,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
@@ -49,6 +50,9 @@ abstract class ProcessAndCopyJniLibsTask : DefaultTask() {
 
     @get:Input
     abstract val useStrippedSoFiles: Property<Boolean>
+
+    @get:Input
+    abstract val extraIgnoredLibs: ListProperty<String>
 
     @get:OutputDirectory
     abstract val outputDirectory: DirectoryProperty
@@ -125,7 +129,8 @@ abstract class ProcessAndCopyJniLibsTask : DefaultTask() {
 
     private fun matchesAllowedLib(name: String): Boolean {
         val isCodegenLib = name.startsWith("libreact_codegen_") && name.endsWith(".so")
-        val isIgnoredLib = IGNORE_EMBEDDED_LIBS.any { lib -> name == lib || name.contains(lib) }
+        val ignoredLibs = IGNORE_EMBEDDED_LIBS + extraIgnoredLibs.getOrElse(emptyList())
+        val isIgnoredLib = ignoredLibs.any { lib -> name == lib || name.contains(lib) }
         return name == "libappmodules.so" || isCodegenLib || !isIgnoredLib
     }
 
@@ -161,6 +166,7 @@ class JNILibsProcessor(val project: Project) {
         val processJniTask =
             project.tasks.register("processCustomJniLibsFor$capitalizedVariantName", ProcessAndCopyJniLibsTask::class.java) {
                 it.useStrippedSoFiles.set(projectExt.useStrippedSoFiles)
+                it.extraIgnoredLibs.set(projectExt.ignoreEmbeddedLibs)
 
                 val jniDirs =
                     aarLibraries.map { aarLib ->

--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/utils/Extension.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/utils/Extension.kt
@@ -42,7 +42,8 @@ open class Extension {
     var missingDimensionStrategies = listOf<String>()
 
     /**
-     * Additional .so file names to keep out of the AAR, on top of [IGNORE_EMBEDDED_LIBS].
+     * Additional .so file names to keep out of the AAR, on top of
+     * [com.callstack.react.brownfield.processors.IGNORE_EMBEDDED_LIBS].
      *
      * Use this for libraries that stay declared as dependencies of the published AAR: the
      * host App resolves those from Maven, so embedding them as well leaves two copies of

--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/utils/Extension.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/utils/Extension.kt
@@ -40,4 +40,16 @@ open class Extension {
      * listOf("type", "alpha")
      */
     var missingDimensionStrategies = listOf<String>()
+
+    /**
+     * Additional .so file names to keep out of the AAR, on top of [IGNORE_EMBEDDED_LIBS].
+     *
+     * Use this for libraries that stay declared as dependencies of the published AAR: the
+     * host App resolves those from Maven, so embedding them as well leaves two copies of
+     * the same .so and the host's native library merge fails.
+     *
+     * Provide in this format:
+     * listOf("libdatadog-ndk.so")
+     */
+    var ignoreEmbeddedLibs = listOf<String>()
 }


### PR DESCRIPTION
## Problem

The plugin embeds `.so` files from the app's dependencies into the AAR, and separately declares those same dependencies in the published Gradle module metadata. When the host App resolves one of them from Maven it ends up with the library twice — once inside the AAR, once from the Maven artifact — and packaging fails:

```
> 2 files found with path 'lib/arm64-v8a/libdatadog-ndk.so' from inputs:
   - .../transformed/<sdk>-release/jni/arm64-v8a/libdatadog-ndk.so
   - .../transformed/dd-sdk-android-ndk-3.11.0/jni/arm64-v8a/libdatadog-ndk.so
Execution failed for task ':app:mergeReleaseNativeLibs'.
```

`IGNORE_EMBEDDED_LIBS` already exists for exactly this situation, and its comment describes it well — libs "provided by the Gradle when AAR is consumed by the host App". But it is a fixed list covering React Native's own libraries, so a project that hits this with any other dependency has no way out of it.

In our app three libraries are in that position: `libdatadog-ndk.so`, `libopentok.so` and `libzstd-kmp.so` — each bundled in the AAR *and* declared in its metadata. Datadog just happens to fail first.

## Solution

Add `reactBrownfield.ignoreEmbeddedLibs`, appended to the built-in list:

```kotlin
reactBrownfield {
    ignoreEmbeddedLibs = listOf("libdatadog-ndk.so", "libopentok.so", "libzstd-kmp.so")
}
```

Default is empty, so behaviour is unchanged for everyone else.

A host can work around this today with `packaging { jniLibs { pickFirsts += ... } }`, but that still ships the duplicate into the AAR and just picks one at packaging time, and it has to be repeated by every integrator. Excluding at the source keeps the AAR correct.

## Test plan

Verified against a real brownfield SDK build (Expo SDK 57 / RN 0.86, New Architecture):

- Before: AAR contained 17 `.so` per ABI including the three above; host app failed at `mergeReleaseNativeLibs` on `libdatadog-ndk.so`.
- After, with the three listed in `ignoreEmbeddedLibs`: AAR contains 14 `.so` per ABI, the three are absent, and the host app's `mergeReleaseNativeLibs` succeeds with no `pickFirsts` workaround.
- With the option unset, the AAR is byte-for-byte what it was before.
