### PR TITLE
feat: enable AGP v9 in BGP

### DIFF
--- a/gradle-plugins/react/brownfield/gradle/libs.versions.toml
+++ b/gradle-plugins/react/brownfield/gradle/libs.versions.toml
@@ -2,8 +2,8 @@
 kotlinJvm = "2.2.21"
 ktlint = "12.1.1"
 detekt = "1.23.7"
-agp = "8.5.2"
-common = "31.2.2" # do not bump it for now, as it throws an error for incompatible AGP used
+agp = "9.2.1"
+common = "32.2.0"
 asm-commons = "9.7"
 versioncompare = "1.5.0"
 

--- a/gradle-plugins/react/brownfield/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle-plugins/react/brownfield/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/shared/MergeClassesTask.kt
+++ b/gradle-plugins/react/brownfield/src/main/kotlin/com/callstack/react/brownfield/shared/MergeClassesTask.kt
@@ -7,6 +7,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputDirectory
@@ -16,6 +17,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 
+@CacheableTask
 abstract class MergeClassesTask : DefaultTask() {
     @get:Classpath
     abstract val inputClassesJars: ConfigurableFileCollection


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

This requires RN App to be v0.87.0 and Expo to be updated and released to the newer version.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

- Tested on https://github.com/callstack/react-native-brownfield/pull/447 - works fine for RNApp
- For Expo, we need to have a new SDK release with RN v0.87.0 