### PR TITLE
feat(ios): add preloadBundle to startReactNative

### DIFF
--- a/.changeset/lucky-pears-preload.md
+++ b/.changeset/lucky-pears-preload.md
@@ -1,0 +1,7 @@
+---
+'@callstack/react-native-brownfield': minor
+---
+
+Add `preloadBundle` to `startReactNative` on iOS. Without a preload, `startReactNative` only makes the factory, and React Native loads the JavaScript bundle when it creates the first React Native view. `startReactNative(launchOptions:preloadBundle:onBundleLoaded:)` moves that work to the app launch: the call starts the React Host, and React Native evaluates the bundle on the JavaScript thread, in parallel with the remainder of the app launch. On Android, `ReactNativeBrownfield.initialize` does the same operation. This shape of `startReactNative` also takes the launch options for the React Host.
+
+`onBundleLoaded` now runs on the main thread, and not on the JavaScript thread. A callback that you add after React Native loaded the bundle runs in the next turn of the main run loop.

--- a/.github/actions/appleapp-road-test/action.yml
+++ b/.github/actions/appleapp-road-test/action.yml
@@ -208,9 +208,7 @@ runs:
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: apps/AppleApp/build
-        key: ${{ runner.os }}-e2e-appleapp-${{ inputs.variant }}-build-${{ hashFiles(format('{0}/ios/Podfile.lock', inputs.rn-project-path), 'apps/AppleApp/Brownfield Apple App.xcodeproj/project.pbxproj', 'apps/brownfield-example-shared-tests/e2e/**') }}
-        restore-keys: |
-          ${{ runner.os }}-e2e-appleapp-${{ inputs.variant }}-build-
+        key: ${{ runner.os }}-e2e-appleapp-${{ inputs.variant }}-build-${{ hashFiles(format('{0}/ios/Podfile.lock', inputs.rn-project-path), 'apps/AppleApp/Brownfield Apple App.xcodeproj/project.pbxproj', 'apps/brownfield-example-shared-tests/e2e/**') }}-${{ hashFiles('apps/AppleApp/package/**/*.swiftinterface') }}
 
     - name: Install Detox iOS artifacts
       if: inputs.run-e2e == 'true'

--- a/apps/AppleApp/Brownfield Apple App/BrownfieldAppleApp.swift
+++ b/apps/AppleApp/Brownfield Apple App/BrownfieldAppleApp.swift
@@ -135,15 +135,17 @@ struct BrownfieldAppleApp: App {
     init() {
         ReactNativeBrownfield.shared.bundle = ReactNativeBundle
         ReactNativeBrownfield.shared.preferEmbeddedBundleInDebug = true
-        ReactNativeBrownfield.shared.startReactNative {
-            print("React Native has been loaded")
-        }
-
         #if USE_EXPO_HOST
             ReactNativeBrownfield.shared.ensureExpoModulesProvider()
         #endif
 
-       BrownfieldStore.register(initialState)
+        BrownfieldStore.register(initialState)
+
+        // `preloadBundle: true` starts the React Host now, and React Native then reads the
+        // bundle URL on the JavaScript thread. Thus this call is the last operation.
+        ReactNativeBrownfield.shared.startReactNative(launchOptions: nil, preloadBundle: true) {
+            print("React Native has been loaded")
+        }
     }
 
     var body: some Scene {

--- a/docs/docs/docs/api-reference/react-native-brownfield/objective-c.mdx
+++ b/docs/docs/docs/api-reference/react-native-brownfield/objective-c.mdx
@@ -44,9 +44,17 @@ A singleton that keeps an instance of `ReactNativeBrownfield` object.
 
 Starts React Native, produces an instance of React Native. You can use it to initialize React Native in your app.
 
-| Param            | Required | Type            | Description                                       |
-| ---------------- | -------- | --------------- | ------------------------------------------------- |
-| `onBundleLoaded` | No       | `void(^)(void)` | Callback invoked after JS bundle is fully loaded. |
+| Param            | Required | Type            | Description                                                                     |
+| ---------------- | -------- | --------------- | ------------------------------------------------------------------------------- |
+| `launchOptions`  | No       | `NSDictionary`  | The launch options for the React Host. Usually you get them from `AppDelegate`. |
+| `preloadBundle`  | No       | `BOOL`          | `YES` loads the JavaScript bundle now, and not with the first React Native view. |
+| `onBundleLoaded` | No       | `void(^)(void)` | Callback invoked on the main thread after JS bundle is fully loaded.            |
+
+Brownfield calls `onBundleLoaded` one time, on the main thread. If React Native already loaded the bundle, the callback runs in the next turn of the main run loop. A new callback replaces the callback that waits.
+
+Without `preloadBundle`, React Native loads and evaluates the JavaScript bundle when it creates the first React Native view. With `preloadBundle:YES`, this call creates and starts the React Host, and React Native then evaluates the bundle on the JavaScript thread, in parallel with the remainder of your app launch. On Android, `ReactNativeBrownfield.initialize` does the same operation. See [Preload the JavaScript bundle](/docs/getting-started/ios#preload-the-javascript-bundle).
+
+Only the call that creates the React Host reads the launch options. Brownfield keeps the options, also if it cannot create the host now. A view that creates the host later uses them. Options that you give to `view` win over these options.
 
 **Examples:**
 
@@ -59,6 +67,17 @@ Starts React Native, produces an instance of React Native. You can use it to ini
     NSLog(@"React Native started");
 }];
 ```
+
+```objc
+[[ReactNativeBrownfield shared] startReactNativeWithLaunchOptions:launchOptions
+                                                    preloadBundle:YES
+                                                   onBundleLoaded:^(void){
+    NSLog(@"React Native bundle loaded");
+}];
+```
+
+> [!Note]
+> With Expo, `preloadBundle` can only prepare the runtime, because Expo can select the bundle after the app starts. See [Expo Integration](/docs/getting-started/expo#xcframework-present-rn-ui).
 
 ##### `stopReactNative`
 

--- a/docs/docs/docs/api-reference/react-native-brownfield/swift.mdx
+++ b/docs/docs/docs/api-reference/react-native-brownfield/swift.mdx
@@ -44,9 +44,17 @@ ReactNativeBrownfield.shared
 
 Starts React Native. You can use it to initialize React Native in your app.
 
-| Param            | Required | Type            | Description                                       |
-| ---------------- | -------- | --------------- | ------------------------------------------------- |
-| `onBundleLoaded` | No       | `(() -> Void)?` | Callback invoked after JS bundle is fully loaded. |
+| Param            | Required | Type                  | Description                                                                     |
+| ---------------- | -------- | --------------------- | ------------------------------------------------------------------------------- |
+| `launchOptions`  | No       | `[AnyHashable: Any]?` | The launch options for the React Host. Usually you get them from `AppDelegate`. |
+| `preloadBundle`  | No       | `Bool`                | `true` loads the JavaScript bundle now, and not with the first React Native view. |
+| `onBundleLoaded` | No       | `(() -> Void)?`       | Callback invoked on the main thread after JS bundle is fully loaded.            |
+
+Brownfield calls `onBundleLoaded` one time, on the main thread. If React Native already loaded the bundle, the callback runs in the next turn of the main run loop. A new callback replaces the callback that waits.
+
+Without `preloadBundle`, React Native loads and evaluates the JavaScript bundle when it creates the first React Native view. With `preloadBundle: true`, this call creates and starts the React Host, and React Native then evaluates the bundle on the JavaScript thread, in parallel with the remainder of your app launch. On Android, `ReactNativeBrownfield.initialize` does the same operation. See [Preload the JavaScript bundle](/docs/getting-started/ios#preload-the-javascript-bundle).
+
+Only the call that creates the React Host reads the launch options. Brownfield keeps the options, also if it cannot create the host now. A view that creates the host later uses them. Options that you give to `view` win over these options.
 
 **Examples:**
 
@@ -59,6 +67,15 @@ ReactNativeBrownfield.shared.startReactNative(onBundleLoaded: {
   print("React Native started")
 })
 ```
+
+```swift
+ReactNativeBrownfield.shared.startReactNative(launchOptions: launchOptions, preloadBundle: true) {
+  print("React Native bundle loaded")
+}
+```
+
+> [!Note]
+> With Expo, `preloadBundle` can only prepare the runtime, because Expo can select the bundle after the app starts. See [Expo Integration](/docs/getting-started/expo#xcframework-present-rn-ui).
 
 ##### `stopReactNative`
 

--- a/docs/docs/docs/getting-started/expo.mdx
+++ b/docs/docs/docs/getting-started/expo.mdx
@@ -124,10 +124,11 @@ struct IosApp: App {
 
     init() {
         ReactNativeBrownfield.shared.bundle = ReactNativeBundle
+        ReactNativeBrownfield.shared.ensureExpoModulesProvider()
+
         ReactNativeBrownfield.shared.startReactNative {
             print("React Native has been loaded")
         }
-        ReactNativeBrownfield.shared.ensureExpoModulesProvider()
     }
 
     var body: some Scene {
@@ -137,6 +138,11 @@ struct IosApp: App {
     }
 }
 ```
+
+To load the JavaScript bundle at the app launch, give `preloadBundle: true` to [`startReactNative`](/docs/api-reference/react-native-brownfield/swift#startreactnative). A preload starts the React Host in that call, and React Native then reads the bundle URL on the JavaScript thread. Thus `startReactNative` must be the last operation. Set `bundle`, `ensureExpoModulesProvider` and every other option before it.
+
+> [!Note]
+> The React Host keeps the first bundle that it evaluates, thus a preload waits until the bundle URL is stable. While Expo can still select a different bundle, `startReactNative` only prepares the runtime, and the first React Native screen loads the bundle. This occurs in a Debug build with `expo-dev-client`, until the user selects an app in the launcher. This also occurs with `expo-updates` in a Release build, until Expo selects the update. Brownfield keeps the launch options of the call, and the first React Native screen uses them. If you set `bundleURLOverride`, the bundle URL cannot change, and a preload always loads the bundle.
 
 If you package the framework in **Debug** and want to run it without Metro, enable the embedded bundle explicitly before calling `startReactNative`:
 

--- a/docs/docs/docs/getting-started/ios.mdx
+++ b/docs/docs/docs/getting-started/ios.mdx
@@ -217,7 +217,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         ReactNativeBrownfield.shared.bundle = ReactNativeBundle
         ReactNativeBrownfield.shared.startReactNative(onBundleLoaded: {
             print("React Native bundle loaded")
-        }, launchOptions: launchOptions)
+        })
 
         window = UIWindow(frame: UIScreen.main.bounds)
 
@@ -231,6 +231,25 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 }
 ```
+
+### Preload the JavaScript bundle
+
+This `startReactNative` call only prepares the runtime. React Native creates and starts the host in `viewWithModuleName:`. Thus React Native loads and evaluates the bundle only when it creates the first React Native screen. React Native also calls `onBundleLoaded` at that time.
+
+To do this work at the app launch, give `preloadBundle: true` to `startReactNative`. On Android, `ReactNativeBrownfield.initialize` does the same operation. This shape of `startReactNative` also takes the launch options:
+
+```swift
+ReactNativeBrownfield.shared.bundle = ReactNativeBundle
+ReactNativeBrownfield.shared.startReactNative(launchOptions: launchOptions, preloadBundle: true) {
+    print("React Native bundle loaded")
+}
+```
+
+A preload creates and starts the React Host in the `startReactNative` call. React Native then reads the bundle URL and evaluates the bundle on the JavaScript thread, in parallel with the remainder of your app launch. Thus `startReactNative` must be the last operation: `bundle`, `bundlePath`, `bundleURLOverride` and every other option must have the final value before the call. An option that you set after the call comes too late, and the JavaScript thread can read it at the same time.
+
+The call itself makes the host and the module registry on the caller's thread. This work is smaller than a bundle evaluation, but it is not free. If you preload React Native in your app's launch critical section, then it impacts your app's launch time. In exchange, the first React Native screen appears faster.
+
+For the rules of `onBundleLoaded` and of the launch options, see [`startReactNative`](/docs/api-reference/react-native-brownfield/swift#startreactnative).
 
 ## 9. Run Your App
 

--- a/packages/react-native-brownfield/ios/BrownfieldReactHostPreloader.h
+++ b/packages/react-native-brownfield/ios/BrownfieldReactHostPreloader.h
@@ -1,0 +1,30 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Creates and starts the React Host, but does not create a view. React Native loads and evaluates
+ * the JavaScript bundle immediately, and not when it mounts the first React Native view.
+ * `viewWithModuleName:` makes the same call internally, thus a view that you create later uses the
+ * host that is ready.
+ *
+ * This class is in Objective-C, because Swift cannot make this call:
+ * `RCTReactNativeFactory.devMenuConfiguration` is nullable, but the related parameter is not
+ * nullable.
+ */
+@interface BrownfieldReactHostPreloader : NSObject
+
+/**
+ * Call this method on the main thread. If a host is already available, this method does nothing.
+ *
+ * @param reactNativeFactory An `RCTReactNativeFactory`, or a subclass, for example
+ *   `ExpoReactNativeFactory`. The type is `id`, because this header must stay free of the React
+ *   Native imports.
+ * @param launchOptions The launch options for the React Host.
+ */
++ (void)preloadWithReactNativeFactory:(id)reactNativeFactory
+                        launchOptions:(nullable NSDictionary *)launchOptions;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/react-native-brownfield/ios/BrownfieldReactHostPreloader.m
+++ b/packages/react-native-brownfield/ios/BrownfieldReactHostPreloader.m
@@ -1,0 +1,113 @@
+#import "BrownfieldReactHostPreloader.h"
+
+// This file is plain Objective-C, and not Objective-C++. The umbrella header of
+// React-RCTAppDelegate imports the Hermes and JSI headers if `__cplusplus` is set. This pod does
+// not have the necessary search paths for those headers. Without C++, the compiler ignores those
+// imports. The compiler then builds the module in the same way that Swift imports it.
+//
+// The name of the pod changes if the build makes it a framework. Thus you must try each possible
+// name. Expo uses the same method in `RCTAppDelegateUmbrella.h`.
+#if __has_include(<React_RCTAppDelegate/RCTRootViewFactory.h>)
+#import <React_RCTAppDelegate/RCTReactNativeFactory.h>
+#import <React_RCTAppDelegate/RCTRootViewFactory.h>
+#elif __has_include(<React-RCTAppDelegate/RCTRootViewFactory.h>)
+#import <React-RCTAppDelegate/RCTReactNativeFactory.h>
+#import <React-RCTAppDelegate/RCTRootViewFactory.h>
+#else
+#import <React/RCTReactNativeFactory.h>
+#import <React/RCTRootViewFactory.h>
+#endif
+
+NS_ASSUME_NONNULL_BEGIN
+
+// `RCTBundleConfiguration` first exists in React Native 0.84. React Native 0.83 does not declare
+// the class. This forward declaration lets the file name the type with both versions.
+@class RCTBundleConfiguration;
+
+/**
+ * The two shapes of `initializeReactHostWithLaunchOptions:...`. React Native 0.83 has the shape
+ * without `bundleConfiguration:`. React Native 0.84 added that parameter and removed the earlier
+ * shape. No header tells the two versions apart at compile time, thus this file declares both
+ * shapes and `respondsToSelector:` selects one at run time. The declarations are equal to the
+ * React Native declarations. The compiler then accepts the file with both versions.
+ */
+@protocol BrownfieldReactHostInitializing <NSObject>
+
+- (void)initializeReactHostWithLaunchOptions:(NSDictionary *__nullable)launchOptions
+                         bundleConfiguration:(RCTBundleConfiguration *)bundleConfiguration
+                        devMenuConfiguration:(RCTDevMenuConfiguration *)devMenuConfiguration;
+
+- (void)initializeReactHostWithLaunchOptions:(NSDictionary *__nullable)launchOptions
+                        devMenuConfiguration:(RCTDevMenuConfiguration *)devMenuConfiguration;
+
+@end
+
+/**
+ * `RCTReactNativeFactory.bundleConfiguration` also first exists in React Native 0.84.
+ */
+@protocol BrownfieldBundleConfigurationProviding <NSObject>
+
+@property (nonatomic, readonly) RCTBundleConfiguration *bundleConfiguration;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+@implementation BrownfieldReactHostPreloader
+
++ (void)preloadWithReactNativeFactory:(id)reactNativeFactory
+                        launchOptions:(NSDictionary *_Nullable)launchOptions
+{
+  RCTReactNativeFactory *factory = (RCTReactNativeFactory *)reactNativeFactory;
+  RCTRootViewFactory *rootViewFactory = factory.rootViewFactory;
+
+  // `initializeReactHostWithLaunchOptions:...` returns early if a view, or an earlier preload,
+  // created a host. Thus this method makes no other check. React Native declares
+  // `rootViewFactory` as not nullable, and this guard is only a protection.
+  if (rootViewFactory == nil) {
+    return;
+  }
+
+  id<BrownfieldReactHostInitializing> hostInitializer = (id)rootViewFactory;
+  SEL initializeWithBundleConfiguration =
+      @selector(initializeReactHostWithLaunchOptions:bundleConfiguration:devMenuConfiguration:);
+  SEL initializeWithDevMenuConfiguration =
+      @selector(initializeReactHostWithLaunchOptions:devMenuConfiguration:);
+
+  // Get the configurations from the factory. Do not make new configurations from the default
+  // values. The Expo runtime sends `RCTReactNativeFactory.devMenuConfiguration` from
+  // `ExpoReactNativeFactory.recreateRootView:`, thus the factory value keeps the two runtimes
+  // equal.
+  //
+  // The preloaded host is equal to a host that a view creates later, but the two paths send
+  // different objects. The bare runtime creates the view with
+  // `viewWithModuleName:initialProperties:launchOptions:`, and that method sends
+  // `[RCTBundleConfiguration defaultConfiguration]` and `[RCTDevMenuConfiguration
+  // defaultConfiguration]`. The values are equal:
+  //   - `RCTReactNativeFactory.bundleConfiguration` gives `[RCTBundleConfiguration
+  //     defaultConfiguration]` while nobody sets another value.
+  //   - `RCTReactNativeFactory.devMenuConfiguration` is nil by default.
+  //     `RCTDevMenuConfigurationDecorator` does nothing with nil, and `RCTDevMenu` and
+  //     `RCTDevSettings` keep their own default values. Those values are equal to
+  //     `[RCTDevMenuConfiguration defaultConfiguration]`, because the two sides read `RCT_DEV_MENU`.
+  if ([hostInitializer respondsToSelector:initializeWithBundleConfiguration]) {
+    id<BrownfieldBundleConfigurationProviding> configurationProvider = (id)factory;
+
+    [hostInitializer initializeReactHostWithLaunchOptions:launchOptions
+                                      bundleConfiguration:configurationProvider.bundleConfiguration
+                                     devMenuConfiguration:factory.devMenuConfiguration];
+  } else if ([hostInitializer respondsToSelector:initializeWithDevMenuConfiguration]) {
+    [hostInitializer initializeReactHostWithLaunchOptions:launchOptions
+                                     devMenuConfiguration:factory.devMenuConfiguration];
+  } else {
+    // A React Native version with a third shape of the method. Do not crash. The first React
+    // Native view creates the host, as without a preload.
+    NSLog(
+        @"%@",
+        @"ReactNativeBrownfield: startReactNative did not preload the JavaScript bundle, because "
+        @"this React Native version has no known initializeReactHostWithLaunchOptions: method. The "
+        @"first React Native view loads the bundle.");
+  }
+}
+
+@end

--- a/packages/react-native-brownfield/ios/Expo/ExpoHostRuntime.swift
+++ b/packages/react-native-brownfield/ios/Expo/ExpoHostRuntime.swift
@@ -11,7 +11,7 @@ internal import EXUpdates
 final class ExpoHostRuntime {
   static let shared = ExpoHostRuntime()
 
-  private let jsBundleLoadObserver = JSBundleLoadObserver()
+  let preloadState = ReactHostPreloadState()
   private var delegate = ExpoHostRuntimeDelegate()
   private var reactNativeFactory: RCTReactNativeFactory?
   private var expoDelegate: ExpoAppDelegate?
@@ -35,9 +35,15 @@ final class ExpoHostRuntime {
   /**
    * Starts React Native with optional callback when bundle is loaded.
    *
-   * @param onBundleLoaded Optional callback invoked after JS bundle is fully loaded.
+   * @param onBundleLoaded Optional callback invoked on the main thread after JS bundle is fully loaded.
    */
   public func startReactNative(onBundleLoaded: (() -> Void)?) {
+    // The callback registration is outside of the guard below. An earlier `startReactNative` call
+    // can already have made the factory, and the callback must still run.
+    if let onBundleLoaded {
+      preloadState.jsBundleLoadObserver.observe(onBundleLoaded: onBundleLoaded)
+    }
+
     guard reactNativeFactory == nil else { return }
 
     let appDelegate = ExpoAppDelegate()
@@ -50,10 +56,6 @@ final class ExpoHostRuntime {
     appDelegate.bindReactNativeFactory(reactNativeFactory)
     #endif
     expoDelegate = appDelegate
-
-    if let onBundleLoaded {
-      jsBundleLoadObserver.observeOnce(onBundleLoaded: onBundleLoaded)
-    }
   }
 
   /**
@@ -70,6 +72,7 @@ final class ExpoHostRuntime {
     }
     reactNativeFactory = nil
     expoDelegate = nil
+    preloadState.reset()
   }
 
   /**
@@ -169,6 +172,8 @@ final class ExpoHostRuntime {
     let bundleURL = delegate.bundleURL()
     configureDevLoadingView(with: bundleURL)
 
+    let resolvedLaunchOptions = preloadState.launchOptions(overriddenBy: launchOptions)
+
     // below: https://github.com/expo/expo/commit/2013760c46cde1404872d181a691da72fbf207a4
     // has moved the recreateRootView method to ExpoReactNativeFactory
     #if EXPO_SDK_GTE_55  // this define comes from the Brownfield Expo config plugin
@@ -176,16 +181,48 @@ final class ExpoHostRuntime {
       withBundleURL: bundleURL,
       moduleName: moduleName,
       initialProps: initialProps,
-      launchOptions: launchOptions
+      launchOptions: resolvedLaunchOptions
     )
     #else
     return expoDelegate?.recreateRootView(
       withBundleURL: bundleURL,
       moduleName: moduleName,
       initialProps: initialProps,
-      launchOptions: launchOptions
+      launchOptions: resolvedLaunchOptions
     )
     #endif
+  }
+}
+
+extension ExpoHostRuntime: ReactHostPreloading {
+  var reactNativeFactoryForPreload: AnyObject? {
+    return reactNativeFactory
+  }
+
+  /**
+   * expo-dev-launcher finds the Metro URL only after the user selects an app in the launcher. This
+   * is a Debug behavior. In Release the class is in the binary, but it does nothing. Thus this
+   * check is also only in Debug.
+   *
+   * The check reads the class name, because this pod has no dependency on expo-dev-launcher.
+   * `EXDevLauncherController` is the name in expo-dev-launcher 56 and 57. If a later version
+   * changes the name, this method gives `true`, and a preload can keep a bundle of the launcher
+   * screen. Examine the name again when you add a new Expo SDK.
+   *
+   * `ExpoHostRuntimeDelegate.isBundleURLStable` covers the other conditions.
+   */
+  func canPreloadReactNative() -> Bool {
+    #if DEBUG
+    if NSClassFromString("EXDevLauncherController") != nil {
+      return false
+    }
+    #endif
+
+    return delegate.isBundleURLStable
+  }
+
+  func prepareDevLoadingView() {
+    configureDevLoadingView()
   }
 }
 
@@ -241,6 +278,31 @@ class ExpoHostRuntimeDelegate: ExpoReactNativeFactoryDelegate {
       assertionFailure("Invalid bundlePath '\(bundlePath)': \(error)")
       return nil
     }
+  }
+
+  /**
+   * `true` if `bundleURL()` gives now the same result as a later resolution. This property follows
+   * the steps of `bundleURL()`, and it must change together with them.
+   *
+   * The override wins over every other step, thus an override makes the URL stable.
+   *
+   * expo-updates selects the launch asset while `AppController` starts. `ReactNativeViewController`
+   * starts `AppController`. Before this operation is complete, `launchAssetUrl()` is nil, and
+   * `bundleURL()` gives the embedded bundle. A host from that time keeps the embedded bundle, and
+   * Expo never applies the update. Thus the URL is stable only after `launchAssetUrl()` has a
+   * value. The class can be in the binary while the app does not use it, thus this check reads the
+   * state and not the class.
+   */
+  var isBundleURLStable: Bool {
+    if bundleURLOverride?() != nil {
+      return true
+    }
+
+    #if canImport(EXUpdates) && !DEBUG
+    return AppController.isInitialized() && AppController.sharedInstance.launchAssetUrl() != nil
+    #else
+    return true
+    #endif
   }
 }
 #endif

--- a/packages/react-native-brownfield/ios/JSBundleLoadObserver.swift
+++ b/packages/react-native-brownfield/ios/JSBundleLoadObserver.swift
@@ -1,38 +1,85 @@
 import Foundation
-internal import React
 
+/**
+ * Watches the `RCTInstanceDidLoadBundle` notification, and calls the callback that waits for it.
+ *
+ * React Native sends the notification from the JavaScript thread. This class always calls the
+ * callback on the main thread, because the callback changes the user interface.
+ *
+ * The class starts to watch at the initialization, and not at the first callback. The class then
+ * knows that React Native loaded the bundle, also if nobody waited for the notification.
+ */
 final class JSBundleLoadObserver {
-  private var onBundleLoaded: (() -> Void)?
+  private var pendingCallback: (() -> Void)?
+  private var didLoadBundle = false
   private var observerToken: NSObjectProtocol?
 
-  func observeOnce(onBundleLoaded: @escaping () -> Void) {
-    removeObserverIfNeeded()
-    self.onBundleLoaded = onBundleLoaded
-
+  init() {
     observerToken = NotificationCenter.default.addObserver(
       forName: NSNotification.Name("RCTInstanceDidLoadBundle"),
       object: nil,
-      queue: nil
+      queue: .main
     ) { [weak self] _ in
-      self?.notifyAndClear()
+      self?.bundleDidLoad()
     }
   }
 
   deinit {
-    removeObserverIfNeeded()
+    if let observerToken {
+      NotificationCenter.default.removeObserver(observerToken)
+    }
   }
 
-  private func notifyAndClear() {
-    let callback = onBundleLoaded
-    onBundleLoaded = nil
-    removeObserverIfNeeded()
+  /**
+   * Keeps one callback, and calls it one time. A new callback replaces the callback that waits. If
+   * React Native already loaded the bundle, the class calls the callback in the next turn of the
+   * main run loop.
+   *
+   * @param onBundleLoaded The class always calls this callback on the main thread.
+   */
+  func observe(onBundleLoaded: @escaping () -> Void) {
+    onMainThread { [weak self] in
+      self?.register(onBundleLoaded)
+    }
+  }
+
+  /**
+   * Removes the callback that waits, and forgets the bundle of the earlier session. Call this
+   * method when you stop React Native. A callback of the earlier session must not run in the next
+   * session.
+   */
+  func reset() {
+    onMainThread { [weak self] in
+      self?.pendingCallback = nil
+      self?.didLoadBundle = false
+    }
+  }
+
+  // MARK: - Main thread only
+
+  private func register(_ onBundleLoaded: @escaping () -> Void) {
+    guard !didLoadBundle else {
+      DispatchQueue.main.async(execute: onBundleLoaded)
+      return
+    }
+
+    pendingCallback = onBundleLoaded
+  }
+
+  private func bundleDidLoad() {
+    didLoadBundle = true
+
+    let callback = pendingCallback
+    pendingCallback = nil
+
     callback?()
   }
 
-  private func removeObserverIfNeeded() {
-    if let observerToken {
-      NotificationCenter.default.removeObserver(observerToken)
-      self.observerToken = nil
+  private func onMainThread(_ work: @escaping () -> Void) {
+    if Thread.isMainThread {
+      work()
+    } else {
+      DispatchQueue.main.async(execute: work)
     }
   }
 }

--- a/packages/react-native-brownfield/ios/ReactHostPreloading.swift
+++ b/packages/react-native-brownfield/ios/ReactHostPreloading.swift
@@ -1,0 +1,177 @@
+import Foundation
+
+/**
+ * The preload state that `startReactNative`, `view` and `stopReactNative` share.
+ */
+final class ReactHostPreloadState {
+  let jsBundleLoadObserver = JSBundleLoadObserver()
+
+  private let lock = NSLock()
+  private var storedLaunchOptions: [AnyHashable: Any]?
+  private var hasPreloadRequest = false
+
+  /**
+   * Keeps the launch options of a `startReactNative` call.
+   *
+   * `startReactNative` can move its preload work to the main thread. A view on the main thread can
+   * create the React Host before that. Thus this method must run at the call, and not after the
+   * change of thread. The view then finds the options.
+   */
+  func storeLaunchOptions(_ launchOptions: [AnyHashable: Any]?) {
+    guard let launchOptions else { return }
+
+    lock.lock()
+    defer { lock.unlock() }
+
+    storedLaunchOptions = launchOptions
+  }
+
+  /**
+   * Records that a `startReactNative` call must preload the bundle. `consumePreloadRequest` reads
+   * the request one time, and `reset` cancels it.
+   */
+  func requestPreload() {
+    lock.lock()
+    defer { lock.unlock() }
+
+    hasPreloadRequest = true
+  }
+
+  /**
+   * `true` if a preload request waits. The method also removes the request.
+   *
+   * `startReactNative` can move its preload work to the main thread. `stopReactNative` on the main
+   * thread can run before that work. The stop cancels the request, thus this method then gives
+   * `false`, and React Native stays stopped.
+   */
+  func consumePreloadRequest() -> Bool {
+    lock.lock()
+    defer { lock.unlock() }
+
+    let hadRequest = hasPreloadRequest
+    hasPreloadRequest = false
+
+    return hadRequest
+  }
+
+  /**
+   * The launch options for a call that can create the React Host. The options of the caller win
+   * over the options of an earlier `startReactNative` call.
+   */
+  func launchOptions(
+    overriddenBy explicitLaunchOptions: [AnyHashable: Any]? = nil
+  ) -> [AnyHashable: Any]? {
+    lock.lock()
+    defer { lock.unlock() }
+
+    return explicitLaunchOptions ?? storedLaunchOptions
+  }
+
+  /**
+   * Removes the state of the session. Call this method when you stop React Native.
+   */
+  func reset() {
+    jsBundleLoadObserver.reset()
+
+    lock.lock()
+    defer { lock.unlock() }
+
+    storedLaunchOptions = nil
+    hasPreloadRequest = false
+  }
+}
+
+/**
+ * The preload sequence that the two host runtimes share. Only one runtime is in a build. The
+ * shared sequence keeps the behavior of the two runtimes equal.
+ */
+protocol ReactHostPreloading: AnyObject {
+  var preloadState: ReactHostPreloadState { get }
+
+  /**
+   * The React Native factory, or nil while React Native did not start. The type is `AnyObject`,
+   * because `BrownfieldReactHostPreloader` also takes the factory as `id`. This file then needs no
+   * React Native import, and it builds with both runtimes.
+   */
+  var reactNativeFactoryForPreload: AnyObject? { get }
+
+  func startReactNative()
+
+  /**
+   * `false` while the bundle URL can still change. The runtime must not create the host in this
+   * condition, because the host keeps the first bundle that it evaluates.
+   */
+  func canPreloadReactNative() -> Bool
+
+  func prepareDevLoadingView()
+}
+
+extension ReactHostPreloading {
+  /**
+   * The implementation of
+   * `ReactNativeBrownfield.startReactNative(launchOptions:preloadBundle:onBundleLoaded:)`, which
+   * holds the contract.
+   */
+  func startReactNative(
+    launchOptions: [AnyHashable: Any]?,
+    preloadBundle: Bool,
+    onBundleLoaded: (() -> Void)?
+  ) {
+    preloadState.storeLaunchOptions(launchOptions)
+
+    if let onBundleLoaded {
+      preloadState.jsBundleLoadObserver.observe(onBundleLoaded: onBundleLoaded)
+    }
+
+    guard preloadBundle else {
+      startReactNative()
+      return
+    }
+
+    preloadState.requestPreload()
+
+    if Thread.isMainThread {
+      createReactHost()
+    } else {
+      DispatchQueue.main.async { [weak self] in
+        self?.createReactHost()
+      }
+    }
+  }
+
+  private func createReactHost() {
+    // `stopReactNative` can run between the request and this method, because a caller that is not
+    // on the main thread moves the work to the main thread. The stop cancels the request, and
+    // React Native must then stay stopped.
+    guard preloadState.consumePreloadRequest() else { return }
+
+    startReactNative()
+
+    guard let factory = reactNativeFactoryForPreload else {
+      logSkippedPreload("React Native did not make the factory")
+      return
+    }
+
+    guard canPreloadReactNative() else {
+      logSkippedPreload("the bundle URL can still change")
+      return
+    }
+
+    // You must configure the dev loading view before React Native loads the bundle. Usually the
+    // `view` method does this.
+    prepareDevLoadingView()
+
+    BrownfieldReactHostPreloader.preload(
+      withReactNativeFactory: factory,
+      launchOptions: preloadState.launchOptions()
+    )
+  }
+
+  private func logSkippedPreload(_ reason: String) {
+    NSLog(
+      "%@",
+      "ReactNativeBrownfield: startReactNative did not preload the JavaScript bundle, because "
+        + reason + ". The first React Native view loads the bundle."
+    )
+  }
+}

--- a/packages/react-native-brownfield/ios/ReactNativeBrownfield.swift
+++ b/packages/react-native-brownfield/ios/ReactNativeBrownfield.swift
@@ -192,13 +192,48 @@ internal import Expo
   /**
    * Starts React Native with optional callback when bundle is loaded.
    *
-   * @param onBundleLoaded Optional callback invoked after JS bundle is fully loaded.
+   * @param onBundleLoaded Optional callback invoked on the main thread after the JS bundle is
+   *   fully loaded. It runs in the next turn of the main run loop when the bundle is already
+   *   loaded. A new callback replaces the callback that waits.
    */
   @objc public func startReactNative(onBundleLoaded: (() -> Void)?) {
     #if canImport(Expo)
     ExpoHostRuntime.shared.startReactNative(onBundleLoaded: onBundleLoaded)
     #else
     ReactNativeHostRuntime.shared.startReactNative(onBundleLoaded: onBundleLoaded)
+    #endif
+  }
+
+  /**
+   * Starts React Native, and optionally loads the JavaScript bundle immediately. Without a
+   * preload, React Native loads the bundle when it creates the first React Native view. On
+   * Android, `ReactNativeBrownfield.initialize` does the same operation.
+   *
+   * @param launchOptions The launch options for the React Host. Only the call that creates the
+   *   host reads these options. This method keeps the options. A view that creates the host later
+   *   uses them, also if this method cannot create the host. Options that you give to `view` win
+   *   over these options.
+   * @param preloadBundle `true` loads and evaluates the JavaScript bundle now. A preload adds
+   *   work to the section of the caller, but the first React Native screen appears faster.
+   * @param onBundleLoaded An optional callback, with the rules of `startReactNative`.
+   */
+  @objc public func startReactNative(
+    launchOptions: [AnyHashable: Any]?,
+    preloadBundle: Bool,
+    onBundleLoaded: (() -> Void)?
+  ) {
+    #if canImport(Expo)
+    ExpoHostRuntime.shared.startReactNative(
+      launchOptions: launchOptions,
+      preloadBundle: preloadBundle,
+      onBundleLoaded: onBundleLoaded
+    )
+    #else
+    ReactNativeHostRuntime.shared.startReactNative(
+      launchOptions: launchOptions,
+      preloadBundle: preloadBundle,
+      onBundleLoaded: onBundleLoaded
+    )
     #endif
   }
 

--- a/packages/react-native-brownfield/ios/Vanilla/ReactNativeHostRuntime.swift
+++ b/packages/react-native-brownfield/ios/Vanilla/ReactNativeHostRuntime.swift
@@ -46,7 +46,7 @@ class ReactNativeBrownfieldDelegate: RCTDefaultReactNativeFactoryDelegate {
 
 final class ReactNativeHostRuntime {
   public static let shared = ReactNativeHostRuntime()
-  private let jsBundleLoadObserver = JSBundleLoadObserver()
+  let preloadState = ReactHostPreloadState()
   private var delegate = ReactNativeBrownfieldDelegate()
 
   private func configureDevLoadingView() {
@@ -133,6 +133,7 @@ final class ReactNativeHostRuntime {
     }
 
     reactNativeFactory = nil
+    preloadState.reset()
   }
 
   public func view(
@@ -145,7 +146,7 @@ final class ReactNativeHostRuntime {
     return reactNativeFactory?.rootViewFactory.view(
       withModuleName: moduleName,
       initialProperties: initialProps,
-      launchOptions: launchOptions
+      launchOptions: preloadState.launchOptions(overriddenBy: launchOptions)
     )
   }
 
@@ -188,17 +189,38 @@ final class ReactNativeHostRuntime {
   /**
    * Starts React Native with optional callback when bundle is loaded.
    *
-   * @param onBundleLoaded Optional callback invoked after JS bundle is fully loaded.
+   * @param onBundleLoaded Optional callback invoked on the main thread after JS bundle is fully loaded.
    */
   public func startReactNative(onBundleLoaded: (() -> Void)?) {
+    // The callback registration is outside of the guard below. An earlier `startReactNative` call
+    // can already have made the factory, and the callback must still run.
+    if let onBundleLoaded {
+      preloadState.jsBundleLoadObserver.observe(onBundleLoaded: onBundleLoaded)
+    }
+
     guard reactNativeFactory == nil else { return }
 
     delegate.dependencyProvider = RCTAppDependencyProvider()
     reactNativeFactory = RCTReactNativeFactory(delegate: delegate)
+  }
+}
 
-    if let onBundleLoaded {
-      jsBundleLoadObserver.observeOnce(onBundleLoaded: onBundleLoaded)
-    }
+extension ReactNativeHostRuntime: ReactHostPreloading {
+  var reactNativeFactoryForPreload: AnyObject? {
+    return reactNativeFactory
+  }
+
+  /**
+   * The bare React Native delegate resolves the bundle URL from the override, from Metro, or from
+   * the embedded bundle. No step waits for an asynchronous operation. Thus a preload uses the same
+   * bundle as the first view.
+   */
+  func canPreloadReactNative() -> Bool {
+    return true
+  }
+
+  func prepareDevLoadingView() {
+    configureDevLoadingView()
   }
 }
 #endif


### PR DESCRIPTION
### Summary

`startReactNative` only builds the factory. React Native creates and starts the host inside `viewWithModuleName:`, thus no JavaScript runs until the app opens the first React Native screen.

This PR adds `startReactNative(launchOptions:preloadBundle:onBundleLoaded:)`. With `preloadBundle: true`, the call creates and starts the React Host at the app launch, and React Native then evaluates the bundle on the JavaScript thread, in parallel with the remainder of the app launch. `onBundleLoaded` fires there. This is the iOS counterpart of Android's `ReactNativeBrownfield.initialize`.

The new shape also takes the launch options for the React Host. Only the call that creates the host reads them. Brownfield keeps the options also when it cannot create the host now, thus a view that creates the host later finds them. Options that you give to `view` win over the kept options.

### The Objective-C shim

`BrownfieldReactHostPreloader` calls `RCTRootViewFactory.initializeReactHostWithLaunchOptions:...`. The shim is plain Objective-C, because Swift cannot make the call: `RCTReactNativeFactory.devMenuConfiguration` is nullable while the matching parameter is not.

The shim declares both shapes of the method and selects one with `respondsToSelector:`, because no header separates RN 0.83 from 0.84:

- RN 0.83: `initializeReactHostWithLaunchOptions:devMenuConfiguration:`
- RN 0.84+: `initializeReactHostWithLaunchOptions:bundleConfiguration:devMenuConfiguration:`

A React Native version with a third shape logs and does not crash, and the first React Native view loads the bundle.

The shim sends the factory's own configurations, and not new default configurations. The preloaded host is then equal to a host that a view creates later. The two paths send different objects: the bare runtime creates the view with `viewWithModuleName:initialProperties:launchOptions:`, which sends `[RCTBundleConfiguration defaultConfiguration]` and `[RCTDevMenuConfiguration defaultConfiguration]`. The values are equal, and the comment in the shim records why.

### Expo

The React Host keeps the first bundle that it evaluates, thus the preload fails closed until the launch asset is known. A preload before `AppController` initializes cannot pin the embedded bundle over an update. `bundleURLOverride` makes the URL stable, and a preload then always loads the bundle. expo-dev-launcher is vetoed only in Debug. When the preload cannot load the bundle it logs, and the first React Native view loads the bundle instead.

`ensureExpoModulesProvider` must now run before `startReactNative`, because the preload starts the host in the call. The docs and the example app show the new order.

### `onBundleLoaded`

React Native posts `RCTInstanceDidLoadBundle` from the JavaScript thread. `JSBundleLoadObserver` now delivers the callback on the main thread. The observer registers at the initialization and not at the first callback, thus it knows that React Native loaded the bundle also when nobody waited. A callback that arrives after the load runs in the next turn of the main run loop. `stopReactNative` clears the pending callback and the recorded load.

This is a behavior change for the existing `startReactNative(onBundleLoaded:)`. The changeset records it.

### Other

- A `stopReactNative` that runs between an off-main-thread `startReactNative` and its main-thread preload work cancels the preload. React Native then stays stopped.
- The AppleApp Detox build cache key now includes the `.swiftinterface` files of the packaged XCFrameworks, and the `restore-keys` fallback is gone. A stale `apps/AppleApp/build` can otherwise link an old `ReactBrownfield` and hide an API change.
- `docs/getting-started/ios.mdx` dropped a `launchOptions:` argument from the plain `startReactNative` example. That overload has never existed, thus the snippet did not compile.

### Test plan

- AppleApp road tests and Detox E2E for the vanilla, Expo 56 and Expo 57 variants. The example app uses `preloadBundle: true`.
- The RN 0.83 branch of the shim has no CI coverage. The matrix covers Expo 56/57 and RNApp, which are RN 0.85 to 0.87.
- No test asserts that the preload occurred. The fallback logs and keeps the app working, thus a regression into the fallback path is silent.
